### PR TITLE
feat: OpenRouter support + cache_control for chat completions

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,19 @@ func main() {
 			return
 		}
 		llmProvider = openai.New(apiKey, "moonshotai/kimi-k2-instruct").WithEndpoint("https://api.groq.com/openai/v1/chat/completions", "Groq")
+	case "openrouter":
+		apiKey := os.Getenv("OPENROUTER_API_KEY")
+		if apiKey == "" {
+			fmt.Println("Error: OPENROUTER_API_KEY environment variable is not set")
+			return
+		}
+		model := "anthropic/claude-sonnet-4"
+		if len(os.Args) > 2 {
+			model = os.Args[2]
+		}
+		llmProvider = openai.New(apiKey, model).
+			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
+			WithCacheControl(true)
 	default:
 		printUsage()
 		return
@@ -206,6 +219,8 @@ func printUsage() {
 	fmt.Println("  anthropic         - Uses Anthropic's Claude Sonnet 4.6 (requires ANTHROPIC_API_KEY)")
 	fmt.Println("  google            - Uses Google's Gemini 3 Flash (requires GEMINI_API_KEY)")
 	fmt.Println("  groq              - Uses kimi-k2-instruct (requires GROQ_API_KEY)")
+	fmt.Println("  openrouter        - Uses OpenRouter with any model (requires OPENROUTER_API_KEY)")
+	fmt.Println("                      Optional: pass model as second arg (default: anthropic/claude-sonnet-4)")
 	fmt.Println()
 	fmt.Println("Environment variables can be set directly or loaded from a .env file.")
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flitsinc/go-llms/google"
 	"github.com/flitsinc/go-llms/llms"
 	"github.com/flitsinc/go-llms/openai"
+	"github.com/flitsinc/go-llms/openrouter"
 	"github.com/flitsinc/go-llms/tools"
 )
 
@@ -93,9 +94,7 @@ func main() {
 		if len(os.Args) > 2 {
 			model = os.Args[2]
 		}
-		llmProvider = openai.New(apiKey, model).
-			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
-			WithCacheControl(true)
+		llmProvider = openrouter.New(apiKey, model)
 	default:
 		printUsage()
 		return

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -30,6 +30,10 @@ type ChatCompletionsAPI struct {
 	includeUsage bool
 
 	customPayloadValues map[string]any
+
+	// When true, emit cache_control on content parts from CacheHint items.
+	// Use for providers like OpenRouter that pass cache_control through to Anthropic.
+	cacheControl bool
 }
 
 func NewChatCompletionsAPI(accessToken, model string) *ChatCompletionsAPI {
@@ -71,6 +75,14 @@ func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI 
 	return m
 }
 
+// WithCacheControl enables emitting cache_control fields on content parts.
+// Use this for providers like OpenRouter that pass cache_control through to
+// upstream providers (e.g. Anthropic) for prompt caching.
+func (m *ChatCompletionsAPI) WithCacheControl(enable bool) *ChatCompletionsAPI {
+	m.cacheControl = enable
+	return m
+}
+
 // WithCustomPayloadValue sets a custom key-value pair in the request payload.
 // Use this for provider-specific parameters not covered by other methods.
 // WARNING: Do not override core fields (stream, model, messages) as this will
@@ -108,12 +120,12 @@ func (m *ChatCompletionsAPI) Generate(
 	if systemPrompt != nil {
 		apiMessages = append(apiMessages, message{
 			Role:    "system",
-			Content: convertContent(systemPrompt),
+			Content: convertContent(systemPrompt, m.cacheControl),
 		})
 	}
 
 	for _, msg := range messages {
-		convertedMsgs := messagesFromLLM(msg)
+		convertedMsgs := messagesFromLLM(msg, m.cacheControl)
 		apiMessages = append(apiMessages, convertedMsgs...)
 	}
 

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -33,6 +33,9 @@ type ChatCompletionsAPI struct {
 
 	// When true, emit cache_control on content parts from CacheHint items.
 	// Use for providers like OpenRouter that pass cache_control through to Anthropic.
+	// TODO: If we need more pass-through exceptions like this, create a dedicated
+	// openrouter Provider implementation instead of adding flags here, and remove
+	// cacheControl from ChatCompletionsAPI.
 	cacheControl bool
 }
 

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -217,7 +217,7 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := messagesFromLLM(tc.input)
+			actual := messagesFromLLM(tc.input, false)
 			assert.Equal(t, len(tc.expected), len(actual), "Number of messages mismatch")
 
 			// Use require for slice length check before iterating

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -27,15 +27,20 @@ type imageURL struct {
 	Detail string `json:"detail,omitempty"`
 }
 
+type cacheControl struct {
+	Type string `json:"type"`
+}
+
 type contentPart struct {
-	Type     string    `json:"type"`
-	Text     *string   `json:"text,omitempty"`
-	ImageURL *imageURL `json:"image_url,omitempty"`
+	Type         string        `json:"type"`
+	Text         *string       `json:"text,omitempty"`
+	ImageURL     *imageURL     `json:"image_url,omitempty"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
 }
 
 type contentList []contentPart
 
-func convertContent(c content.Content) contentList {
+func convertContent(c content.Content, emitCacheControl bool) contentList {
 	cl := make(contentList, 0, len(c))
 	for _, item := range c {
 		var cp contentPart
@@ -58,7 +63,10 @@ func convertContent(c content.Content) contentList {
 			// OpenAI does not expect thinking tokens as input; ignore.
 			continue
 		case *content.CacheHint:
-			// Cache hints are handled at the request level via prompt_cache_retention.
+			// When cacheControl is enabled, attach cache_control to the preceding content part.
+			if emitCacheControl && len(cl) > 0 {
+				cl[len(cl)-1].CacheControl = &cacheControl{Type: "ephemeral"}
+			}
 			continue
 		default:
 			panic(fmt.Sprintf("unhandled content item type %T", item))
@@ -98,7 +106,7 @@ type message struct {
 
 // messagesFromLLM converts an llms.Message to the OpenAI API message format.
 // It may return multiple messages if the input is a tool result with auxiliary content.
-func messagesFromLLM(m llms.Message) []message {
+func messagesFromLLM(m llms.Message, emitCacheControl bool) []message {
 	if m.Role == "tool" {
 		var messagesToReturn []message
 		var primaryResultString string
@@ -132,7 +140,7 @@ func messagesFromLLM(m llms.Message) []message {
 		messagesToReturn = append(messagesToReturn, primaryMessage)
 
 		if len(secondaryContent) > 0 {
-			secondaryAPIContent := convertContent(secondaryContent)
+			secondaryAPIContent := convertContent(secondaryContent, emitCacheControl)
 			if len(secondaryAPIContent) > 0 {
 				secondaryMessage := message{
 					Role:    "user",
@@ -145,7 +153,7 @@ func messagesFromLLM(m llms.Message) []message {
 	}
 
 	apiRole := m.Role
-	apiContent := convertContent(m.Content)
+	apiContent := convertContent(m.Content, emitCacheControl)
 
 	if len(apiContent) == 0 && len(m.ToolCalls) == 0 {
 		return []message{}

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -77,7 +77,7 @@ func convertContent(c content.Content, emitCacheControl bool) contentList {
 }
 
 func (cl contentList) MarshalJSON() ([]byte, error) {
-	if len(cl) == 1 && cl[0].Type == "text" && cl[0].Text != nil {
+	if len(cl) == 1 && cl[0].Type == "text" && cl[0].Text != nil && cl[0].CacheControl == nil {
 		return json.Marshal(*cl[0].Text)
 	}
 	return json.Marshal([]contentPart(cl))

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -1,0 +1,12 @@
+package openrouter
+
+import "github.com/flitsinc/go-llms/openai"
+
+// New creates an OpenAI-compatible ChatCompletionsAPI configured for OpenRouter.
+// Cache control is enabled by default so that CacheHint items are passed through
+// to upstream providers (e.g. Anthropic) for prompt caching.
+func New(apiKey, model string) *openai.ChatCompletionsAPI {
+	return openai.New(apiKey, model).
+		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
+		WithCacheControl(true)
+}


### PR DESCRIPTION
## Summary
- Adds `WithCacheControl(bool)` to `ChatCompletionsAPI` — when enabled, `CacheHint` items in content are emitted as `cache_control: {"type": "ephemeral"}` on the preceding content part
- Adds OpenRouter as a test provider in `main.go` with configurable model (default `anthropic/claude-sonnet-4`)
- Verified end-to-end: cache write on first request, cache hit on second request via OpenRouter → Anthropic

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Live tested OpenRouter provider with tool calling (3 turns)
- [x] Verified `WithCacheControl(true)` produces cache writes + cache hits with ~2k token prompts
- [x] Verified `WithCacheControl(false)` produces no caching (control test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Chat Completions request/message serialization and JSON marshaling behavior (though gated behind `WithCacheControl`), which could subtly affect provider compatibility and caching semantics.
> 
> **Overview**
> Adds an `openrouter` provider option that routes Chat Completions requests to OpenRouter (model selectable via CLI arg) and enables pass-through prompt caching support by default.
> 
> Extends `openai.ChatCompletionsAPI` with `WithCacheControl`, allowing `content.CacheHint` items to be converted into `cache_control:{"type":"ephemeral"}` on the preceding content part, and updates message/content conversion + tests to thread this flag through without changing default OpenAI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0f20b3e37f302e646ff668c84be696f6bcbb5bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->