### PR TITLE
feat: stream thinking tokens via OpenRouter chat completions

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,15 @@ func main() {
 		llmProvider = google.New("gemini-3-flash-preview").
 			WithThinkingLevel(google.ThinkingLevelLow).
 			WithGeminiAPI(apiKey)
+	case "cerebras":
+		apiKey := os.Getenv("CEREBRAS_API_KEY")
+		if apiKey == "" {
+			fmt.Println("Error: CEREBRAS_API_KEY environment variable is not set")
+			return
+		}
+		llmProvider = openai.New(apiKey, "llama3.1-8b").
+			WithEndpoint("https://api.cerebras.ai/v1/chat/completions", "Cerebras").
+			WithIncludeUsage(false)
 	case "groq":
 		apiKey := os.Getenv("GROQ_API_KEY")
 		if apiKey == "" {
@@ -99,6 +108,14 @@ func main() {
 		} else {
 			llmProvider = openrouter.New(apiKey, model)
 		}
+	case "xai":
+		apiKey := os.Getenv("XAI_API_KEY")
+		if apiKey == "" {
+			fmt.Println("Error: XAI_API_KEY environment variable is not set")
+			return
+		}
+		llmProvider = openai.New(apiKey, "grok-3-mini").
+			WithEndpoint("https://api.x.ai/v1/chat/completions", "xAI")
 	default:
 		printUsage()
 		return
@@ -215,16 +232,18 @@ func printUsage() {
 	fmt.Println("Usage: go run main.go <provider>")
 	fmt.Println()
 	fmt.Println("Supported providers:")
-	fmt.Println("  openai            - Uses OpenAI Chat Completions with gpt-5.4 (requires OPENAI_API_KEY)")
-	fmt.Println("  openai-responses  - Uses OpenAI Responses API with gpt-5.4 (requires OPENAI_API_KEY)")
-	fmt.Println("  openai-ws         - Uses OpenAI Responses API over WebSocket (requires OPENAI_API_KEY)")
-	fmt.Println("  openai-ws-warmup  - Same as openai-ws but with Warmup pre-loading (requires OPENAI_API_KEY)")
-	fmt.Println("  anthropic         - Uses Anthropic's Claude Sonnet 4.6 (requires ANTHROPIC_API_KEY)")
-	fmt.Println("  google            - Uses Google's Gemini 3 Flash (requires GEMINI_API_KEY)")
-	fmt.Println("  groq              - Uses kimi-k2-instruct (requires GROQ_API_KEY)")
+	fmt.Println("  openai              - Uses OpenAI Chat Completions with gpt-5.4 (requires OPENAI_API_KEY)")
+	fmt.Println("  openai-responses    - Uses OpenAI Responses API with gpt-5.4 (requires OPENAI_API_KEY)")
+	fmt.Println("  openai-ws           - Uses OpenAI Responses API over WebSocket (requires OPENAI_API_KEY)")
+	fmt.Println("  openai-ws-warmup    - Same as openai-ws but with Warmup pre-loading (requires OPENAI_API_KEY)")
+	fmt.Println("  anthropic           - Uses Anthropic's Claude Sonnet 4.6 (requires ANTHROPIC_API_KEY)")
+	fmt.Println("  cerebras            - Uses Cerebras Llama 3.1 8B (requires CEREBRAS_API_KEY)")
+	fmt.Println("  google              - Uses Google's Gemini 3 Flash (requires GEMINI_API_KEY)")
+	fmt.Println("  groq                - Uses kimi-k2-instruct (requires GROQ_API_KEY)")
 	fmt.Println("  openrouter          - Uses OpenRouter with any model (requires OPENROUTER_API_KEY)")
 	fmt.Println("  openrouter-thinking - Same as openrouter but with medium reasoning effort")
 	fmt.Println("                        Optional: pass model as second arg (default: anthropic/claude-sonnet-4)")
+	fmt.Println("  xai                 - Uses xAI's Grok 3 Mini (requires XAI_API_KEY)")
 	fmt.Println()
 	fmt.Println("Environment variables can be set directly or loaded from a .env file.")
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 			return
 		}
 		llmProvider = openai.New(apiKey, "moonshotai/kimi-k2-instruct").WithEndpoint("https://api.groq.com/openai/v1/chat/completions", "Groq")
-	case "openrouter":
+	case "openrouter", "openrouter-thinking":
 		apiKey := os.Getenv("OPENROUTER_API_KEY")
 		if apiKey == "" {
 			fmt.Println("Error: OPENROUTER_API_KEY environment variable is not set")
@@ -94,7 +94,11 @@ func main() {
 		if len(os.Args) > 2 {
 			model = os.Args[2]
 		}
-		llmProvider = openrouter.New(apiKey, model)
+		if provider == "openrouter-thinking" {
+			llmProvider = openrouter.NewWithReasoning(apiKey, model, openrouter.Reasoning{Effort: "medium"})
+		} else {
+			llmProvider = openrouter.New(apiKey, model)
+		}
 	default:
 		printUsage()
 		return
@@ -218,8 +222,9 @@ func printUsage() {
 	fmt.Println("  anthropic         - Uses Anthropic's Claude Sonnet 4.6 (requires ANTHROPIC_API_KEY)")
 	fmt.Println("  google            - Uses Google's Gemini 3 Flash (requires GEMINI_API_KEY)")
 	fmt.Println("  groq              - Uses kimi-k2-instruct (requires GROQ_API_KEY)")
-	fmt.Println("  openrouter        - Uses OpenRouter with any model (requires OPENROUTER_API_KEY)")
-	fmt.Println("                      Optional: pass model as second arg (default: anthropic/claude-sonnet-4)")
+	fmt.Println("  openrouter          - Uses OpenRouter with any model (requires OPENROUTER_API_KEY)")
+	fmt.Println("  openrouter-thinking - Same as openrouter but with medium reasoning effort")
+	fmt.Println("                        Optional: pass model as second arg (default: anthropic/claude-sonnet-4)")
 	fmt.Println()
 	fmt.Println("Environment variables can be set directly or loaded from a .env file.")
 	fmt.Println()

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -415,14 +415,25 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 	var activeToolCallIndex = -1 // Track the index of the tool call being processed
 	messageStartYielded := false
 
-	return func(yield func(llms.StreamStatus) bool) {
+	return func(rawYield func(llms.StreamStatus) bool) {
+		stopped := false
+		yield := func(status llms.StreamStatus) bool {
+			if !rawYield(status) {
+				stopped = true
+				return false
+			}
+			return true
+		}
 		defer io.Copy(io.Discard, s.stream)
 		defer func() {
 			// Ensure ThinkingDone is emitted if the stream ends abnormally
 			// (e.g. EOF without [DONE]) while still in thinking state.
+			// Don't call yield if the consumer already stopped iterating.
 			if s.lastThought != nil {
 				s.lastThought = nil
-				yield(llms.StreamStatusThinkingDone)
+				if !stopped {
+					rawYield(llms.StreamStatusThinkingDone)
+				}
 			}
 		}()
 		for {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -451,7 +451,14 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				continue
 			}
 			if line == "[DONE]" {
-				// Stream ended. If a tool call was active, mark it as ready.
+				// Stream ended. If we were still thinking, emit ThinkingDone.
+				if s.lastThought != nil {
+					s.lastThought = nil
+					if !yield(llms.StreamStatusThinkingDone) {
+						return
+					}
+				}
+				// If a tool call was active, mark it as ready.
 				if activeToolCallIndex != -1 {
 					if !yield(llms.StreamStatusToolCallReady) {
 						return
@@ -491,6 +498,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					s.lastThought = &content.Thought{}
 				}
 				s.lastThought.Text = text
+				s.message.Content.AppendThought(text)
 				if !yield(llms.StreamStatusThinking) {
 					return
 				}

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -410,6 +410,14 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 
 	return func(yield func(llms.StreamStatus) bool) {
 		defer io.Copy(io.Discard, s.stream)
+		defer func() {
+			// Ensure ThinkingDone is emitted if the stream ends abnormally
+			// (e.g. EOF without [DONE]) while still in thinking state.
+			if s.lastThought != nil {
+				s.lastThought = nil
+				yield(llms.StreamStatusThinkingDone)
+			}
+		}()
 		for {
 			select {
 			case <-s.ctx.Done():
@@ -505,7 +513,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 			}
 
 			// Content is nullable string in delta
-			if delta.Content != nil {
+			if delta.Content != nil && *delta.Content != "" {
 				// If we were thinking and now got content, emit ThinkingDone.
 				if s.lastThought != nil {
 					s.lastThought = nil

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -528,14 +528,26 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				}
 			}
 			// Handle reasoning/thinking tokens from providers that include them
-			// in the OpenAI-compatible streaming format.
+			// in the OpenAI-compatible streaming format. Prefer delta.Reasoning
+			// for text; fall back to reasoning_details[].Text if absent.
+			reasoningText := ""
 			if delta.Reasoning != nil && *delta.Reasoning != "" {
-				text := *delta.Reasoning
+				reasoningText = *delta.Reasoning
+			}
+			if reasoningText == "" {
+				for _, rd := range delta.ReasoningDetails {
+					if rd.Text != "" {
+						reasoningText = rd.Text
+						break
+					}
+				}
+			}
+			if reasoningText != "" {
 				if s.lastThought == nil {
 					s.lastThought = &content.Thought{}
 				}
-				s.lastThought.Text = text
-				s.message.Content.AppendThought(text)
+				s.lastThought.Text = reasoningText
+				s.message.Content.AppendThought(reasoningText)
 				if !yield(llms.StreamStatusThinking) {
 					return
 				}

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -551,11 +551,9 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					}
 				}
 				s.lastText = *delta.Content
-				if s.lastText != "" {
-					s.message.Content.Append(s.lastText)
-					if !yield(llms.StreamStatusText) {
-						return
-					}
+				s.message.Content.Append(s.lastText)
+				if !yield(llms.StreamStatusText) {
+					return
 				}
 			}
 

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -540,6 +540,19 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					return
 				}
 			}
+			// Capture signature from reasoning_details (arrives on the final
+			// reasoning chunk, separate from the text deltas).
+			for _, rd := range delta.ReasoningDetails {
+				if rd.Signature != "" {
+					// Ensure there's a thought to attach the signature to.
+					if s.lastThought == nil {
+						s.lastThought = &content.Thought{}
+						s.message.Content.AppendThought("")
+					}
+					s.message.Content.SetThoughtSignature(rd.Signature)
+					s.lastThought.Signature = rd.Signature
+				}
+			}
 
 			// Content is nullable string in delta
 			if delta.Content != nil && *delta.Content != "" {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -347,14 +347,15 @@ func (m *ChatCompletionsAPI) Generate(
 }
 
 type ChatCompletionsStream struct {
-	ctx      context.Context
-	model    string
-	stream   io.Reader
-	debugger llms.Debugger
-	err      error
-	message  llms.Message
-	lastText string
-	usage    *usage
+	ctx         context.Context
+	model       string
+	stream      io.Reader
+	debugger    llms.Debugger
+	err         error
+	message     llms.Message
+	lastText    string
+	lastThought *content.Thought
+	usage       *usage
 }
 
 func (s *ChatCompletionsStream) Err() error {
@@ -383,8 +384,9 @@ func (s *ChatCompletionsStream) ToolCall() llms.ToolCall {
 }
 
 func (s *ChatCompletionsStream) Thought() content.Thought {
-	// OpenAI API does not currently stream thoughts through Chat Completions API.
-	// TODO: Switch to Responses API to support this.
+	if s.lastThought != nil {
+		return *s.lastThought
+	}
 	return content.Thought{}
 }
 
@@ -480,8 +482,27 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					return
 				}
 			}
+			// Handle reasoning/thinking tokens (e.g. from OpenRouter → Anthropic)
+			if delta.Reasoning != nil && *delta.Reasoning != "" {
+				text := *delta.Reasoning
+				if s.lastThought == nil {
+					s.lastThought = &content.Thought{}
+				}
+				s.lastThought.Text = text
+				if !yield(llms.StreamStatusThinking) {
+					return
+				}
+			}
+
 			// Content is nullable string in delta
 			if delta.Content != nil {
+				// If we were thinking and now got content, emit ThinkingDone.
+				if s.lastThought != nil {
+					s.lastThought = nil
+					if !yield(llms.StreamStatusThinkingDone) {
+						return
+					}
+				}
 				s.lastText = *delta.Content
 				if s.lastText != "" {
 					s.message.Content.Append(s.lastText)
@@ -493,6 +514,13 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 
 			// Handle Tool Calls Delta
 			if len(delta.ToolCalls) > 0 {
+				// If we were thinking and now got tool calls, emit ThinkingDone.
+				if s.lastThought != nil {
+					s.lastThought = nil
+					if !yield(llms.StreamStatusThinkingDone) {
+						return
+					}
+				}
 				for _, toolDelta := range delta.ToolCalls {
 					if toolDelta.Index >= len(s.message.ToolCalls) {
 						// This is a new tool call starting

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -30,6 +30,10 @@ type ChatCompletionsAPI struct {
 	includeUsage bool
 
 	customPayloadValues map[string]any
+
+	// When set, include prompt_cache_retention in requests that contain a "long"
+	// cache hint. This is an OpenAI-specific feature.
+	promptCacheRetention string
 }
 
 func NewChatCompletionsAPI(accessToken, model string) *ChatCompletionsAPI {
@@ -68,6 +72,14 @@ func (m *ChatCompletionsAPI) WithVerbosity(verbosity Verbosity) *ChatCompletions
 // WithIncludeUsage sets whether to include stream_options.include_usage in requests.
 func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI {
 	m.includeUsage = include
+	return m
+}
+
+// WithPromptCacheRetention enables extended prompt caching with the given
+// retention duration (e.g. "24h") when content contains a "long" cache hint.
+// This is an OpenAI-specific feature.
+func (m *ChatCompletionsAPI) WithPromptCacheRetention(retention string) *ChatCompletionsAPI {
+	m.promptCacheRetention = retention
 	return m
 }
 
@@ -140,10 +152,8 @@ func (m *ChatCompletionsAPI) BuildPayload(
 		payload["verbosity"] = m.verbosity
 	}
 
-	// Enable extended prompt caching (24h) when any content contains a "long" cache hint.
-	// Only send for OpenAI's own endpoint; other providers reject this parameter.
-	if m.endpoint == "https://api.openai.com/v1/chat/completions" && hasLongCacheHint(systemPrompt, messages) {
-		payload["prompt_cache_retention"] = "24h"
+	if m.promptCacheRetention != "" && hasLongCacheHint(systemPrompt, messages) {
+		payload["prompt_cache_retention"] = m.promptCacheRetention
 	}
 
 	for k, v := range m.customPayloadValues {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -156,7 +156,9 @@ func (m *ChatCompletionsAPI) Generate(
 	}
 
 	// Enable extended prompt caching (24h) when any content contains a "long" cache hint.
-	if hasLongCacheHint(systemPrompt, messages) {
+	// Only send this for OpenAI's own endpoint; other providers don't support it
+	// (OpenRouter uses cache_control on content parts instead).
+	if !m.cacheControl && m.endpoint == "https://api.openai.com/v1/chat/completions" && hasLongCacheHint(systemPrompt, messages) {
 		payload["prompt_cache_retention"] = "24h"
 	}
 

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -30,13 +30,6 @@ type ChatCompletionsAPI struct {
 	includeUsage bool
 
 	customPayloadValues map[string]any
-
-	// When true, emit cache_control on content parts from CacheHint items.
-	// Use for providers like OpenRouter that pass cache_control through to Anthropic.
-	// TODO: If we need more pass-through exceptions like this, create a dedicated
-	// openrouter Provider implementation instead of adding flags here, and remove
-	// cacheControl from ChatCompletionsAPI.
-	cacheControl bool
 }
 
 func NewChatCompletionsAPI(accessToken, model string) *ChatCompletionsAPI {
@@ -78,14 +71,6 @@ func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI 
 	return m
 }
 
-// WithCacheControl enables emitting cache_control fields on content parts.
-// Use this for providers like OpenRouter that pass cache_control through to
-// upstream providers (e.g. Anthropic) for prompt caching.
-func (m *ChatCompletionsAPI) WithCacheControl(enable bool) *ChatCompletionsAPI {
-	m.cacheControl = enable
-	return m
-}
-
 // WithCustomPayloadValue sets a custom key-value pair in the request payload.
 // Use this for provider-specific parameters not covered by other methods.
 // WARNING: Do not override core fields (stream, model, messages) as this will
@@ -110,25 +95,25 @@ func (m *ChatCompletionsAPI) Model() string {
 	return m.model
 }
 
-func (m *ChatCompletionsAPI) Generate(
-	ctx context.Context,
+// BuildPayload constructs the request payload without sending it.
+// This is exported so wrapper providers (e.g. OpenRouter) can modify the payload
+// before calling DoRequest.
+func (m *ChatCompletionsAPI) BuildPayload(
 	systemPrompt content.Content,
 	messages []llms.Message,
 	toolbox *tools.Toolbox,
 	jsonOutputSchema *tools.ValueSchema,
-) llms.ProviderStream {
-	debugger := llms.GetDebugger(ctx)
-
-	var apiMessages []message
+) (map[string]any, error) {
+	var apiMessages []Message
 	if systemPrompt != nil {
-		apiMessages = append(apiMessages, message{
+		apiMessages = append(apiMessages, Message{
 			Role:    "system",
-			Content: convertContent(systemPrompt, m.cacheControl),
+			Content: ConvertContent(systemPrompt),
 		})
 	}
 
 	for _, msg := range messages {
-		convertedMsgs := messagesFromLLM(msg, m.cacheControl)
+		convertedMsgs := MessagesFromLLM(msg)
 		apiMessages = append(apiMessages, convertedMsgs...)
 	}
 
@@ -156,9 +141,8 @@ func (m *ChatCompletionsAPI) Generate(
 	}
 
 	// Enable extended prompt caching (24h) when any content contains a "long" cache hint.
-	// Only send this for OpenAI's own endpoint; other providers don't support it
-	// (OpenRouter uses cache_control on content parts instead).
-	if !m.cacheControl && m.endpoint == "https://api.openai.com/v1/chat/completions" && hasLongCacheHint(systemPrompt, messages) {
+	// Only send for OpenAI's own endpoint; other providers reject this parameter.
+	if m.endpoint == "https://api.openai.com/v1/chat/completions" && hasLongCacheHint(systemPrompt, messages) {
 		payload["prompt_cache_retention"] = "24h"
 	}
 
@@ -201,7 +185,7 @@ func (m *ChatCompletionsAPI) Generate(
 					}
 				}
 				if !exists {
-					return &ChatCompletionsStream{err: fmt.Errorf("openai chat: no allowed tools found in toolbox")}
+					return nil, fmt.Errorf("openai chat: no allowed tools found in toolbox")
 				}
 				// Build allowed_tools object
 				allowed := make([]ChatAllowedTool, 0, len(choice.AllowedTools))
@@ -227,7 +211,7 @@ func (m *ChatCompletionsAPI) Generate(
 					}
 				}
 				if !exists {
-					return &ChatCompletionsStream{err: fmt.Errorf("openai chat: required tool %q not found in toolbox", name)}
+					return nil, fmt.Errorf("openai chat: required tool %q not found in toolbox", name)
 				}
 				payload["tool_choice"] = ChatToolChoice{Type: "function", Function: &ChatToolChoiceFunc{Name: name}}
 			default:
@@ -252,7 +236,7 @@ func (m *ChatCompletionsAPI) Generate(
 					}
 				}
 				if !exists {
-					return &ChatCompletionsStream{err: fmt.Errorf("openai chat: none of the required tools are present in toolbox")}
+					return nil, fmt.Errorf("openai chat: none of the required tools are present in toolbox")
 				}
 				allowed := make([]ChatAllowedTool, 0, len(choice.AllowedTools))
 				for _, n := range choice.AllowedTools {
@@ -277,6 +261,29 @@ func (m *ChatCompletionsAPI) Generate(
 			},
 		}
 	}
+
+	return payload, nil
+}
+
+func (m *ChatCompletionsAPI) Generate(
+	ctx context.Context,
+	systemPrompt content.Content,
+	messages []llms.Message,
+	toolbox *tools.Toolbox,
+	jsonOutputSchema *tools.ValueSchema,
+) llms.ProviderStream {
+	payload, err := m.BuildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
+	if err != nil {
+		return &ChatCompletionsStream{err: err}
+	}
+	return m.DoRequest(ctx, payload)
+}
+
+// DoRequest sends a pre-built payload and returns a streaming response.
+// This is exported so wrapper providers (e.g. OpenRouter) can build/modify a
+// payload via BuildPayload and then send it.
+func (m *ChatCompletionsAPI) DoRequest(ctx context.Context, payload map[string]any) llms.ProviderStream {
+	debugger := llms.GetDebugger(ctx)
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -552,17 +553,33 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					return
 				}
 			}
-			// Capture signature from reasoning_details (arrives on the final
-			// reasoning chunk, separate from the text deltas).
+			// Process reasoning_details for signatures and encrypted thinking.
 			for _, rd := range delta.ReasoningDetails {
 				if rd.Signature != "" {
-					// Ensure there's a thought to attach the signature to.
+					// Signature arrives on the final reasoning chunk.
 					if s.lastThought == nil {
 						s.lastThought = &content.Thought{}
 						s.message.Content.AppendThought("")
 					}
 					s.message.Content.SetThoughtSignature(rd.Signature)
 					s.lastThought.Signature = rd.Signature
+				}
+				if rd.Type == "reasoning.encrypted" && rd.Data != "" {
+					decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
+					if err != nil {
+						s.err = fmt.Errorf("error decoding encrypted reasoning data: %w", err)
+						return
+					}
+					thought := &content.Thought{
+						Text:      "(Redacted)",
+						Encrypted: decodedData,
+						Summary:   true,
+					}
+					s.lastThought = thought
+					s.message.Content = append(s.message.Content, thought)
+					if !yield(llms.StreamStatusThinking) {
+						return
+					}
 				}
 			}
 

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -517,7 +517,8 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					return
 				}
 			}
-			// Handle reasoning/thinking tokens (e.g. from OpenRouter → Anthropic)
+			// Handle reasoning/thinking tokens from providers that include them
+			// in the OpenAI-compatible streaming format.
 			if delta.Reasoning != nil && *delta.Reasoning != "" {
 				text := *delta.Reasoning
 				if s.lastThought == nil {

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -18,7 +18,7 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    llms.Message
-		expected []message
+		expected []Message
 	}{
 		{
 			name: "User message - text only",
@@ -26,10 +26,10 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				Role:    "user",
 				Content: content.FromText("Hello there"),
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role: "user",
-					Content: contentList{
+					Content: ContentList{
 						{Type: "text", Text: ptr("Hello there")},
 					},
 				},
@@ -41,10 +41,10 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				Role:    "user",
 				Content: content.FromTextAndImage("Look at this:", "data:image/png;base64,abc"),
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role: "user",
-					Content: contentList{
+					Content: ContentList{
 						{Type: "text", Text: ptr("Look at this:")},
 						{Type: "image_url", ImageURL: &imageURL{URL: "data:image/png;base64,abc", Detail: "auto"}},
 					},
@@ -57,10 +57,10 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				Role:    "assistant",
 				Content: content.FromText("I am here to help."),
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role: "assistant",
-					Content: contentList{
+					Content: ContentList{
 						{Type: "text", Text: ptr("I am here to help.")},
 					},
 				},
@@ -75,10 +75,10 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				},
 				Content: content.FromText("Okay, getting weather."), // Content often empty but test just in case
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role: "assistant",
-					Content: contentList{ // Ensure content is still converted
+					Content: ContentList{ // Ensure content is still converted
 						{Type: "text", Text: ptr("Okay, getting weather.")},
 					},
 					ToolCalls: []toolCall{
@@ -96,7 +96,7 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				},
 				Content: content.Content{}, // Empty content
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role:    "assistant",
 					Content: nil, // Content should be nil so it's omitted from JSON
@@ -120,7 +120,7 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 					},
 				},
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role:    "assistant",
 					Content: nil,
@@ -137,11 +137,11 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				ToolCallID: "call_123",
 				Content:    content.FromRawJSON(json.RawMessage(`{"temp": 25}`)),
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role:       "tool",
 					ToolCallID: "call_123",
-					Content:    contentList{{Type: "text", Text: ptr(`{"temp": 25}`)}}, // Result stringified
+					Content:    ContentList{{Type: "text", Text: ptr(`{"temp": 25}`)}}, // Result stringified
 				},
 			},
 		},
@@ -152,11 +152,11 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 				ToolCallID: "call_456",
 				Content:    content.FromText("Command executed successfully"),
 			},
-			expected: []message{
+			expected: []Message{
 				{
 					Role:       "tool",
 					ToolCallID: "call_456",
-					Content:    contentList{{Type: "text", Text: ptr("Command executed successfully")}},
+					Content:    ContentList{{Type: "text", Text: ptr("Command executed successfully")}},
 				},
 			},
 		},
@@ -170,15 +170,15 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 					&content.Text{Text: "Process finished."},
 				},
 			},
-			expected: []message{
+			expected: []Message{
 				{ // Primary tool result message
 					Role:       "tool",
 					ToolCallID: "call_789",
-					Content:    contentList{{Type: "text", Text: ptr(`{"status": "done"}`)}},
+					Content:    ContentList{{Type: "text", Text: ptr(`{"status": "done"}`)}},
 				},
 				{ // Secondary user message for the extra text
 					Role: "user",
-					Content: contentList{
+					Content: ContentList{
 						{Type: "text", Text: ptr("Process finished.")},
 					},
 				},
@@ -194,15 +194,15 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 					&content.ImageURL{URL: "data:image/png;base64,xyz"},
 				},
 			},
-			expected: []message{
+			expected: []Message{
 				{ // Primary tool result message
 					Role:       "tool",
 					ToolCallID: "call_abc",
-					Content:    contentList{{Type: "text", Text: ptr(`{"plot_generated": true}`)}},
+					Content:    ContentList{{Type: "text", Text: ptr(`{"plot_generated": true}`)}},
 				},
 				{ // Secondary user message for the extra image
 					Role: "user",
-					Content: contentList{
+					Content: ContentList{
 						{Type: "image_url", ImageURL: &imageURL{URL: "data:image/png;base64,xyz", Detail: "auto"}},
 					},
 				},
@@ -211,13 +211,13 @@ func TestMessagesFromLLM_OpenAI(t *testing.T) {
 		{
 			name:     "Empty message",
 			input:    llms.Message{Role: "user", Content: nil},
-			expected: []message{}, // Should produce no message if content and tool calls are empty
+			expected: []Message{}, // Should produce no message if content and tool calls are empty
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := messagesFromLLM(tc.input, false)
+			actual := MessagesFromLLM(tc.input)
 			assert.Equal(t, len(tc.expected), len(actual), "Number of messages mismatch")
 
 			// Use require for slice length check before iterating

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -27,23 +27,29 @@ type imageURL struct {
 	Detail string `json:"detail,omitempty"`
 }
 
-type cacheControl struct {
+// CacheControl represents a cache control directive on a content part.
+type CacheControl struct {
 	Type string `json:"type"`
 }
 
-type contentPart struct {
+// ContentPart represents a single part of a message's content array.
+type ContentPart struct {
 	Type         string        `json:"type"`
 	Text         *string       `json:"text,omitempty"`
 	ImageURL     *imageURL     `json:"image_url,omitempty"`
-	CacheControl *cacheControl `json:"cache_control,omitempty"`
+	CacheControl *CacheControl `json:"cache_control,omitempty"`
 }
 
-type contentList []contentPart
+// ContentList is a list of content parts with custom JSON marshaling.
+type ContentList []ContentPart
 
-func convertContent(c content.Content, emitCacheControl bool) contentList {
-	cl := make(contentList, 0, len(c))
+// ConvertContent converts content.Content to a ContentList for the OpenAI API.
+// CacheHint items are skipped; use openrouter.ConvertContentWithCacheControl
+// for providers that support cache_control on content parts.
+func ConvertContent(c content.Content) ContentList {
+	cl := make(ContentList, 0, len(c))
 	for _, item := range c {
-		var cp contentPart
+		var cp ContentPart
 		switch v := item.(type) {
 		case *content.Text:
 			cp.Type = "text"
@@ -63,10 +69,7 @@ func convertContent(c content.Content, emitCacheControl bool) contentList {
 			// OpenAI does not expect thinking tokens as input; ignore.
 			continue
 		case *content.CacheHint:
-			// When cacheControl is enabled, attach cache_control to the preceding content part.
-			if emitCacheControl && len(cl) > 0 {
-				cl[len(cl)-1].CacheControl = &cacheControl{Type: "ephemeral"}
-			}
+			// Cache hints are handled at the request level via prompt_cache_retention.
 			continue
 		default:
 			panic(fmt.Sprintf("unhandled content item type %T", item))
@@ -76,39 +79,40 @@ func convertContent(c content.Content, emitCacheControl bool) contentList {
 	return cl
 }
 
-func (cl contentList) MarshalJSON() ([]byte, error) {
+func (cl ContentList) MarshalJSON() ([]byte, error) {
 	if len(cl) == 1 && cl[0].Type == "text" && cl[0].Text != nil && cl[0].CacheControl == nil {
 		return json.Marshal(*cl[0].Text)
 	}
-	return json.Marshal([]contentPart(cl))
+	return json.Marshal([]ContentPart(cl))
 }
 
-func (cl *contentList) UnmarshalJSON(data []byte) error {
+func (cl *ContentList) UnmarshalJSON(data []byte) error {
 	var text string
 	if err := json.Unmarshal(data, &text); err == nil {
-		*cl = contentList{{Type: "text", Text: &text}}
+		*cl = ContentList{{Type: "text", Text: &text}}
 		return nil
 	}
-	var value []contentPart
+	var value []ContentPart
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*cl = contentList(value)
+	*cl = ContentList(value)
 	return nil
 }
 
-type message struct {
+// Message represents a chat message in the OpenAI API format.
+type Message struct {
 	Role       string      `json:"role"`
-	Content    contentList `json:"content,omitempty"`
+	Content    ContentList `json:"content,omitempty"`
 	ToolCalls  []toolCall  `json:"tool_calls,omitempty"`
 	ToolCallID string      `json:"tool_call_id,omitempty"`
 }
 
-// messagesFromLLM converts an llms.Message to the OpenAI API message format.
+// MessagesFromLLM converts an llms.Message to the OpenAI API message format.
 // It may return multiple messages if the input is a tool result with auxiliary content.
-func messagesFromLLM(m llms.Message, emitCacheControl bool) []message {
+func MessagesFromLLM(m llms.Message) []Message {
 	if m.Role == "tool" {
-		var messagesToReturn []message
+		var messagesToReturn []Message
 		var primaryResultString string
 		var secondaryContent content.Content
 
@@ -132,17 +136,17 @@ func messagesFromLLM(m llms.Message, emitCacheControl bool) []message {
 			primaryResultString = ""
 		}
 
-		primaryMessage := message{
+		primaryMessage := Message{
 			Role:       "tool",
-			Content:    contentList{{Type: "text", Text: &primaryResultString}},
+			Content:    ContentList{{Type: "text", Text: &primaryResultString}},
 			ToolCallID: m.ToolCallID,
 		}
 		messagesToReturn = append(messagesToReturn, primaryMessage)
 
 		if len(secondaryContent) > 0 {
-			secondaryAPIContent := convertContent(secondaryContent, emitCacheControl)
+			secondaryAPIContent := ConvertContent(secondaryContent)
 			if len(secondaryAPIContent) > 0 {
-				secondaryMessage := message{
+				secondaryMessage := Message{
 					Role:    "user",
 					Content: secondaryAPIContent,
 				}
@@ -153,13 +157,13 @@ func messagesFromLLM(m llms.Message, emitCacheControl bool) []message {
 	}
 
 	apiRole := m.Role
-	apiContent := convertContent(m.Content, emitCacheControl)
+	apiContent := ConvertContent(m.Content)
 
 	if len(apiContent) == 0 && len(m.ToolCalls) == 0 {
-		return []message{}
+		return []Message{}
 	}
 
-	msg := message{
+	msg := Message{
 		Role:    apiRole,
 		Content: apiContent,
 	}
@@ -196,7 +200,7 @@ func messagesFromLLM(m llms.Message, emitCacheControl bool) []message {
 		}
 	}
 
-	return []message{msg}
+	return []Message{msg}
 }
 
 func normalizeOpenAIToolType(metaType string) string {

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -280,8 +280,9 @@ func (t toolCallDelta) ToLLM() llms.ToolCall {
 // ReasoningDetail represents a reasoning token entry from providers that stream
 // thinking via the OpenAI-compatible format (e.g. OpenRouter).
 type ReasoningDetail struct {
-	Type      string `json:"type"`                // e.g. "reasoning.text"
+	Type      string `json:"type"`                // "reasoning.text" or "reasoning.encrypted"
 	Text      string `json:"text,omitempty"`      // reasoning text (streamed per chunk)
+	Data      string `json:"data,omitempty"`      // base64-encoded encrypted thinking
 	Signature string `json:"signature,omitempty"` // Anthropic signature (final chunk only)
 	Format    string `json:"format,omitempty"`    // e.g. "anthropic-claude-v1"
 	Index     int    `json:"index,omitempty"`

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -273,11 +273,23 @@ func (t toolCallDelta) ToLLM() llms.ToolCall {
 	panic(fmt.Sprintf("malformed tool call delta with ID %q: both Function and Custom are nil or invalid", t.ID))
 }
 
+// reasoningDetail represents a single reasoning token from providers like
+// OpenRouter that stream thinking via the OpenAI-compatible format.
+type reasoningDetail struct {
+	Type   string `json:"type"`             // e.g. "reasoning.text", "reasoning.summary", "reasoning.encrypted"
+	ID     string `json:"id,omitempty"`     // unique identifier
+	Text   string `json:"text,omitempty"`   // for "reasoning.text" type
+	Format string `json:"format,omitempty"` // e.g. "anthropic-claude-v1"
+	Index  int    `json:"index,omitempty"`
+}
+
 type chatCompletionDelta struct {
-	Role      string          `json:"role,omitempty"`
-	Content   *string         `json:"content,omitempty"`
-	Refusal   *string         `json:"refusal,omitempty"`
-	ToolCalls []toolCallDelta `json:"tool_calls,omitempty"`
+	Role             string            `json:"role,omitempty"`
+	Content          *string           `json:"content,omitempty"`
+	Refusal          *string           `json:"refusal,omitempty"`
+	Reasoning        *string           `json:"reasoning,omitempty"`
+	ReasoningDetails []reasoningDetail `json:"reasoning_details,omitempty"`
+	ToolCalls        []toolCallDelta   `json:"tool_calls,omitempty"`
 }
 
 type logprobsContent struct {

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -277,12 +277,23 @@ func (t toolCallDelta) ToLLM() llms.ToolCall {
 	panic(fmt.Sprintf("malformed tool call delta with ID %q: both Function and Custom are nil or invalid", t.ID))
 }
 
+// ReasoningDetail represents a reasoning token entry from providers that stream
+// thinking via the OpenAI-compatible format (e.g. OpenRouter).
+type ReasoningDetail struct {
+	Type      string `json:"type"`                // e.g. "reasoning.text"
+	Text      string `json:"text,omitempty"`      // reasoning text (streamed per chunk)
+	Signature string `json:"signature,omitempty"` // Anthropic signature (final chunk only)
+	Format    string `json:"format,omitempty"`    // e.g. "anthropic-claude-v1"
+	Index     int    `json:"index,omitempty"`
+}
+
 type chatCompletionDelta struct {
-	Role      string          `json:"role,omitempty"`
-	Content   *string         `json:"content,omitempty"`
-	Refusal   *string         `json:"refusal,omitempty"`
-	Reasoning *string         `json:"reasoning,omitempty"`
-	ToolCalls []toolCallDelta `json:"tool_calls,omitempty"`
+	Role             string            `json:"role,omitempty"`
+	Content          *string           `json:"content,omitempty"`
+	Refusal          *string           `json:"refusal,omitempty"`
+	Reasoning        *string           `json:"reasoning,omitempty"`
+	ReasoningDetails []ReasoningDetail `json:"reasoning_details,omitempty"`
+	ToolCalls        []toolCallDelta   `json:"tool_calls,omitempty"`
 }
 
 type logprobsContent struct {

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -273,23 +273,12 @@ func (t toolCallDelta) ToLLM() llms.ToolCall {
 	panic(fmt.Sprintf("malformed tool call delta with ID %q: both Function and Custom are nil or invalid", t.ID))
 }
 
-// reasoningDetail represents a single reasoning token from providers like
-// OpenRouter that stream thinking via the OpenAI-compatible format.
-type reasoningDetail struct {
-	Type   string `json:"type"`             // e.g. "reasoning.text", "reasoning.summary", "reasoning.encrypted"
-	ID     string `json:"id,omitempty"`     // unique identifier
-	Text   string `json:"text,omitempty"`   // for "reasoning.text" type
-	Format string `json:"format,omitempty"` // e.g. "anthropic-claude-v1"
-	Index  int    `json:"index,omitempty"`
-}
-
 type chatCompletionDelta struct {
-	Role             string            `json:"role,omitempty"`
-	Content          *string           `json:"content,omitempty"`
-	Refusal          *string           `json:"refusal,omitempty"`
-	Reasoning        *string           `json:"reasoning,omitempty"`
-	ReasoningDetails []reasoningDetail `json:"reasoning_details,omitempty"`
-	ToolCalls        []toolCallDelta   `json:"tool_calls,omitempty"`
+	Role      string          `json:"role,omitempty"`
+	Content   *string         `json:"content,omitempty"`
+	Refusal   *string         `json:"refusal,omitempty"`
+	Reasoning *string         `json:"reasoning,omitempty"`
+	ToolCalls []toolCallDelta `json:"tool_calls,omitempty"`
 }
 
 type logprobsContent struct {

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/flitsinc/go-llms/content"
 	"github.com/flitsinc/go-llms/llms"
@@ -76,8 +77,8 @@ func (p *Provider) Generate(
 		return &errorStream{err: err}
 	}
 
-	// Replace messages with cache_control-aware versions.
-	var apiMessages []openai.Message
+	// Replace messages with cache_control-aware versions and reasoning continuity.
+	var apiMessages []any
 	if systemPrompt != nil {
 		apiMessages = append(apiMessages, openai.Message{
 			Role:    "system",
@@ -121,17 +122,86 @@ func convertContentWithCacheControl(c content.Content) openai.ContentList {
 	return cl
 }
 
-// messagesWithCacheControl converts an llms.Message to OpenAI API messages
-// with cache_control support on content parts.
-func messagesWithCacheControl(m llms.Message) []openai.Message {
+// messageWithReasoning wraps a base message and adds reasoning_details.
+// It uses custom JSON marshaling to preserve all base message fields.
+type messageWithReasoning struct {
+	base             openai.Message
+	reasoningDetails []openai.ReasoningDetail
+}
+
+func (m messageWithReasoning) MarshalJSON() ([]byte, error) {
+	// Marshal base message to a map, then add reasoning_details.
+	data, err := json.Marshal(m.base)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	rd, err := json.Marshal(m.reasoningDetails)
+	if err != nil {
+		return nil, err
+	}
+	obj["reasoning_details"] = rd
+	return json.Marshal(obj)
+}
+
+// messagesWithCacheControl converts an llms.Message to API messages with
+// cache_control support and reasoning continuity for assistant messages.
+func messagesWithCacheControl(m llms.Message) []any {
 	msgs := openai.MessagesFromLLM(m)
+
 	// For non-tool messages, re-convert content with cache control.
 	if m.Role != "tool" && len(m.Content) > 0 {
 		for i := range msgs {
 			msgs[i].Content = convertContentWithCacheControl(m.Content)
 		}
 	}
-	return msgs
+
+	// For assistant messages, extract thoughts and emit as reasoning_details.
+	if m.Role == "assistant" {
+		var details []openai.ReasoningDetail
+		var thoughtText string
+		var signature string
+		for _, item := range m.Content {
+			if t, ok := item.(*content.Thought); ok {
+				thoughtText += t.Text
+				if t.Signature != "" {
+					signature = t.Signature
+				}
+			}
+		}
+		if thoughtText != "" || signature != "" {
+			detail := openai.ReasoningDetail{
+				Type:   "reasoning.text",
+				Text:   thoughtText,
+				Format: "anthropic-claude-v1",
+				Index:  0,
+			}
+			if signature != "" {
+				detail.Signature = signature
+			}
+			details = append(details, detail)
+		}
+		if len(details) > 0 {
+			result := make([]any, len(msgs))
+			for i, msg := range msgs {
+				result[i] = messageWithReasoning{
+					base:             msg,
+					reasoningDetails: details,
+				}
+			}
+			return result
+		}
+	}
+
+	// Default: return as-is
+	result := make([]any, len(msgs))
+	for i, msg := range msgs {
+		result[i] = msg
+	}
+	return result
 }
 
 // errorStream is a minimal ProviderStream that only returns an error.

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -72,6 +72,9 @@ func (p *Provider) Generate(
 	toolbox *tools.Toolbox,
 	jsonOutputSchema *tools.ValueSchema,
 ) llms.ProviderStream {
+	// BuildPayload handles tools, response_format, and other non-message fields.
+	// We rebuild messages below with cache_control and reasoning_details, so the
+	// messages built by BuildPayload are replaced.
 	payload, err := p.ChatCompletionsAPI.BuildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
 	if err != nil {
 		return &errorStream{err: err}
@@ -101,6 +104,10 @@ func (p *Provider) Generate(
 // convertContentWithCacheControl converts content.Content to a ContentList,
 // attaching cache_control: {"type": "ephemeral"} to content parts that precede
 // a CacheHint. This enables prompt caching for Anthropic models via OpenRouter.
+//
+// Note: this walks the original content to find CacheHint positions while
+// tracking which items ConvertContent skips (Thought, CacheHint). If
+// ConvertContent starts skipping new types, this function must be updated.
 func convertContentWithCacheControl(c content.Content) openai.ContentList {
 	cl := openai.ConvertContent(c)
 
@@ -174,10 +181,8 @@ func messagesWithCacheControl(m llms.Message) []any {
 		}
 		if thoughtText != "" || signature != "" {
 			detail := openai.ReasoningDetail{
-				Type:   "reasoning.text",
-				Text:   thoughtText,
-				Format: "anthropic-claude-v1",
-				Index:  0,
+				Type: "reasoning.text",
+				Text: thoughtText,
 			}
 			if signature != "" {
 				detail.Signature = signature

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -2,6 +2,11 @@ package openrouter
 
 import "github.com/flitsinc/go-llms/openai"
 
+// Reasoning configures thinking/reasoning behavior for OpenRouter requests.
+type Reasoning struct {
+	Effort string `json:"effort,omitempty"` // "xhigh", "high", "medium", "low", "minimal", "none"
+}
+
 // New creates an OpenAI-compatible ChatCompletionsAPI configured for OpenRouter.
 // Cache control is enabled by default so that CacheHint items are passed through
 // to upstream providers (e.g. Anthropic) for prompt caching.
@@ -9,4 +14,10 @@ func New(apiKey, model string) *openai.ChatCompletionsAPI {
 	return openai.New(apiKey, model).
 		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
 		WithCacheControl(true)
+}
+
+// NewWithReasoning creates an OpenRouter provider with reasoning/thinking enabled.
+func NewWithReasoning(apiKey, model string, reasoning Reasoning) *openai.ChatCompletionsAPI {
+	return New(apiKey, model).
+		WithCustomPayloadValue("reasoning", reasoning)
 }

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 
 	"github.com/flitsinc/go-llms/content"
@@ -172,7 +173,17 @@ func messagesWithCacheControl(m llms.Message) []any {
 		var thoughtText string
 		var signature string
 		for _, item := range m.Content {
-			if t, ok := item.(*content.Thought); ok {
+			t, ok := item.(*content.Thought)
+			if !ok {
+				continue
+			}
+			if len(t.Encrypted) > 0 {
+				// Encrypted/redacted thinking — emit as reasoning.encrypted.
+				details = append(details, openai.ReasoningDetail{
+					Type: "reasoning.encrypted",
+					Data: base64.StdEncoding.EncodeToString(t.Encrypted),
+				})
+			} else {
 				thoughtText += t.Text
 				if t.Signature != "" {
 					signature = t.Signature

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -36,6 +36,34 @@ func NewWithReasoning(apiKey, model string, reasoning Reasoning) *Provider {
 	return p
 }
 
+// Builder method overrides — these delegate to ChatCompletionsAPI but return
+// *Provider so that method chaining doesn't silently downcast to the base type.
+
+func (p *Provider) WithMaxCompletionTokens(n int) *Provider {
+	p.ChatCompletionsAPI.WithMaxCompletionTokens(n)
+	return p
+}
+
+func (p *Provider) WithThinking(effort openai.Effort) *Provider {
+	p.ChatCompletionsAPI.WithThinking(effort)
+	return p
+}
+
+func (p *Provider) WithVerbosity(verbosity openai.Verbosity) *Provider {
+	p.ChatCompletionsAPI.WithVerbosity(verbosity)
+	return p
+}
+
+func (p *Provider) WithIncludeUsage(include bool) *Provider {
+	p.ChatCompletionsAPI.WithIncludeUsage(include)
+	return p
+}
+
+func (p *Provider) WithCustomPayloadValue(key string, value any) *Provider {
+	p.ChatCompletionsAPI.WithCustomPayloadValue(key, value)
+	return p
+}
+
 func (p *Provider) Generate(
 	ctx context.Context,
 	systemPrompt content.Content,

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -61,9 +61,6 @@ func (p *Provider) Generate(
 	}
 	payload["messages"] = apiMessages
 
-	// OpenRouter doesn't support prompt_cache_retention; remove it.
-	delete(payload, "prompt_cache_retention")
-
 	// Add reasoning parameter if configured.
 	if p.reasoning != nil {
 		payload["reasoning"] = p.reasoning

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -1,23 +1,124 @@
 package openrouter
 
-import "github.com/flitsinc/go-llms/openai"
+import (
+	"context"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/flitsinc/go-llms/openai"
+	"github.com/flitsinc/go-llms/tools"
+)
 
 // Reasoning configures thinking/reasoning behavior for OpenRouter requests.
 type Reasoning struct {
 	Effort string `json:"effort,omitempty"` // "xhigh", "high", "medium", "low", "minimal", "none"
 }
 
-// New creates an OpenAI-compatible ChatCompletionsAPI configured for OpenRouter.
-// Cache control is enabled by default so that CacheHint items are passed through
-// to upstream providers (e.g. Anthropic) for prompt caching.
-func New(apiKey, model string) *openai.ChatCompletionsAPI {
-	return openai.New(apiKey, model).
-		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
-		WithCacheControl(true)
+// Provider wraps ChatCompletionsAPI with OpenRouter-specific behavior:
+// cache_control on content parts, no prompt_cache_retention, and optional reasoning.
+type Provider struct {
+	*openai.ChatCompletionsAPI
+	reasoning *Reasoning
+}
+
+// New creates an OpenRouter provider.
+func New(apiKey, model string) *Provider {
+	return &Provider{
+		ChatCompletionsAPI: openai.New(apiKey, model).
+			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter"),
+	}
 }
 
 // NewWithReasoning creates an OpenRouter provider with reasoning/thinking enabled.
-func NewWithReasoning(apiKey, model string, reasoning Reasoning) *openai.ChatCompletionsAPI {
-	return New(apiKey, model).
-		WithCustomPayloadValue("reasoning", reasoning)
+func NewWithReasoning(apiKey, model string, reasoning Reasoning) *Provider {
+	p := New(apiKey, model)
+	p.reasoning = &reasoning
+	return p
 }
+
+func (p *Provider) Generate(
+	ctx context.Context,
+	systemPrompt content.Content,
+	messages []llms.Message,
+	toolbox *tools.Toolbox,
+	jsonOutputSchema *tools.ValueSchema,
+) llms.ProviderStream {
+	payload, err := p.ChatCompletionsAPI.BuildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
+	if err != nil {
+		return &errorStream{err: err}
+	}
+
+	// Replace messages with cache_control-aware versions.
+	var apiMessages []openai.Message
+	if systemPrompt != nil {
+		apiMessages = append(apiMessages, openai.Message{
+			Role:    "system",
+			Content: convertContentWithCacheControl(systemPrompt),
+		})
+	}
+	for _, msg := range messages {
+		apiMessages = append(apiMessages, messagesWithCacheControl(msg)...)
+	}
+	payload["messages"] = apiMessages
+
+	// OpenRouter doesn't support prompt_cache_retention; remove it.
+	delete(payload, "prompt_cache_retention")
+
+	// Add reasoning parameter if configured.
+	if p.reasoning != nil {
+		payload["reasoning"] = p.reasoning
+	}
+
+	return p.ChatCompletionsAPI.DoRequest(ctx, payload)
+}
+
+// convertContentWithCacheControl converts content.Content to a ContentList,
+// attaching cache_control: {"type": "ephemeral"} to content parts that precede
+// a CacheHint. This enables prompt caching for Anthropic models via OpenRouter.
+func convertContentWithCacheControl(c content.Content) openai.ContentList {
+	cl := openai.ConvertContent(c)
+
+	// Walk through original content to find CacheHint positions and attach
+	// cache_control to the corresponding preceding content part.
+	clIdx := 0
+	for _, item := range c {
+		switch item.(type) {
+		case *content.CacheHint:
+			if clIdx > 0 {
+				cl[clIdx-1].CacheControl = &openai.CacheControl{Type: "ephemeral"}
+			}
+		case *content.Thought:
+			// Skipped by ConvertContent, don't advance index.
+		default:
+			clIdx++
+		}
+	}
+	return cl
+}
+
+// messagesWithCacheControl converts an llms.Message to OpenAI API messages
+// with cache_control support on content parts.
+func messagesWithCacheControl(m llms.Message) []openai.Message {
+	msgs := openai.MessagesFromLLM(m)
+	// For non-tool messages, re-convert content with cache control.
+	if m.Role != "tool" && len(m.Content) > 0 {
+		for i := range msgs {
+			msgs[i].Content = convertContentWithCacheControl(m.Content)
+		}
+	}
+	return msgs
+}
+
+// errorStream is a minimal ProviderStream that only returns an error.
+type errorStream struct {
+	err error
+}
+
+func (s *errorStream) Err() error                                    { return s.err }
+func (s *errorStream) Iter() func(yield func(llms.StreamStatus) bool) { return func(func(llms.StreamStatus) bool) {} }
+func (s *errorStream) Message() llms.Message                         { return llms.Message{} }
+func (s *errorStream) Text() string                                  { return "" }
+func (s *errorStream) Image() (string, string)                       { return "", "" }
+func (s *errorStream) Thought() content.Thought                      { return content.Thought{} }
+func (s *errorStream) ToolCall() llms.ToolCall                       { return llms.ToolCall{} }
+func (s *errorStream) Usage() llms.Usage                             { return llms.Usage{} }


### PR DESCRIPTION
## Summary
- Parses `reasoning` and `reasoning_details` fields from the streaming delta in the chat completions path, yielding `StreamStatusThinking` / `StreamStatusThinkingDone` events
- Adds `openrouter.NewWithReasoning()` constructor for easy thinking configuration via the `reasoning` request parameter
- Adds `openrouter-thinking` test provider in `main.go`

## Test plan
- [x] All existing tests pass
- [x] Live tested with `anthropic/claude-sonnet-4` — thinking tokens stream correctly before tool calls and text
- [x] Live tested with `anthropic/claude-opus-4-6` — same behavior confirmed
- [x] `openrouter` (without thinking) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming parsing and provider wrappers, which can subtly affect message/tool-call boundaries and client event ordering. Scope is contained to OpenAI-compatible Chat Completions and OpenRouter-specific request shaping.
> 
> **Overview**
> **Adds streaming *thinking* support for OpenAI-compatible Chat Completions.** The stream parser now recognizes `reasoning` / `reasoning_details` deltas (including base64 `reasoning.encrypted` and signatures), emits `StreamStatusThinking` / `StreamStatusThinkingDone`, and ensures thinking is closed before text/tool-call events and on abnormal stream termination.
> 
> **Refactors request construction to support wrapper providers.** `ChatCompletionsAPI` is split into `BuildPayload` + `DoRequest`, replaces the old `cache_control` flag with an explicit `WithPromptCacheRetention(...)` option, and exports `ConvertContent`/`MessagesFromLLM` types for reuse.
> 
> **Introduces a real `openrouter.Provider`.** OpenRouter now rebuilds messages to attach `cache_control` for `CacheHint`s and (optionally) includes a `reasoning` request parameter via `NewWithReasoning`; `main.go` adds an `openrouter-thinking` mode plus new `cerebras` and `xai` provider options and updates CLI usage text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6235ce582bb4b3353d2d34c781b37789d1886f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->