### PR TITLE
[codex] Refactor OpenRouter into shared Chat Completions

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -93,6 +93,9 @@ type Thought struct {
 	Text      string `json:"text,omitempty"`
 	Encrypted []byte `json:"encrypted,omitempty"`
 	Signature string `json:"signature,omitempty"`
+	// Metadata holds protocol-specific metadata that should be forwarded unchanged.
+	// Keys are prefixed with the protocol/provider name, e.g. "openai:format".
+	Metadata map[string]string `json:"metadata,omitempty"`
 	// Summary is true if the thought is a complete summary of the thinking
 	// session, as opposed to the actual thinking stream.
 	Summary bool `json:"summary"`
@@ -100,6 +103,10 @@ type Thought struct {
 
 func (t *Thought) Type() Type {
 	return TypeThought
+}
+
+func (t *Thought) GetMetadata() map[string]string {
+	return t.Metadata
 }
 
 type CacheHint struct {

--- a/llms/before_response.go
+++ b/llms/before_response.go
@@ -135,19 +135,19 @@ func cloneContent(c content.Content) content.Content {
 			out = append(out, &content.ImageURL{
 				URL:      v.URL,
 				MimeType: v.MimeType,
-				Metadata: cloneStringMap(v.Metadata),
+				Metadata: cloneMetadata(v.Metadata),
 			})
 		case *content.AudioURL:
 			out = append(out, &content.AudioURL{
 				URL:      v.URL,
 				MimeType: v.MimeType,
-				Metadata: cloneStringMap(v.Metadata),
+				Metadata: cloneMetadata(v.Metadata),
 			})
 		case *content.VideoURL:
 			out = append(out, &content.VideoURL{
 				URL:      v.URL,
 				MimeType: v.MimeType,
-				Metadata: cloneStringMap(v.Metadata),
+				Metadata: cloneMetadata(v.Metadata),
 			})
 		case *content.JSON:
 			out = append(out, &content.JSON{Data: append([]byte(nil), v.Data...)})
@@ -157,7 +157,7 @@ func cloneContent(c content.Content) content.Content {
 				Text:      v.Text,
 				Encrypted: append([]byte(nil), v.Encrypted...),
 				Signature: v.Signature,
-				Metadata:  cloneStringMap(v.Metadata),
+				Metadata:  cloneMetadata(v.Metadata),
 				Summary:   v.Summary,
 			})
 		case *content.CacheHint:
@@ -165,17 +165,6 @@ func cloneContent(c content.Content) content.Content {
 		default:
 			out = append(out, item)
 		}
-	}
-	return out
-}
-
-func cloneStringMap(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
 	}
 	return out
 }

--- a/llms/before_response.go
+++ b/llms/before_response.go
@@ -132,7 +132,23 @@ func cloneContent(c content.Content) content.Content {
 		case *content.Text:
 			out = append(out, &content.Text{Text: v.Text})
 		case *content.ImageURL:
-			out = append(out, &content.ImageURL{URL: v.URL, MimeType: v.MimeType})
+			out = append(out, &content.ImageURL{
+				URL:      v.URL,
+				MimeType: v.MimeType,
+				Metadata: cloneStringMap(v.Metadata),
+			})
+		case *content.AudioURL:
+			out = append(out, &content.AudioURL{
+				URL:      v.URL,
+				MimeType: v.MimeType,
+				Metadata: cloneStringMap(v.Metadata),
+			})
+		case *content.VideoURL:
+			out = append(out, &content.VideoURL{
+				URL:      v.URL,
+				MimeType: v.MimeType,
+				Metadata: cloneStringMap(v.Metadata),
+			})
 		case *content.JSON:
 			out = append(out, &content.JSON{Data: append([]byte(nil), v.Data...)})
 		case *content.Thought:
@@ -141,6 +157,7 @@ func cloneContent(c content.Content) content.Content {
 				Text:      v.Text,
 				Encrypted: append([]byte(nil), v.Encrypted...),
 				Signature: v.Signature,
+				Metadata:  cloneStringMap(v.Metadata),
 				Summary:   v.Summary,
 			})
 		case *content.CacheHint:
@@ -148,6 +165,17 @@ func cloneContent(c content.Content) content.Content {
 		default:
 			out = append(out, item)
 		}
+	}
+	return out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
 	}
 	return out
 }

--- a/llms/before_response_test.go
+++ b/llms/before_response_test.go
@@ -187,6 +187,43 @@ func TestBeforeResponseHookCanAbort(t *testing.T) {
 	assert.Len(t, provider.Calls(), 0, "provider should not be called after before-response abort")
 }
 
+func TestCloneMessages_PreservesContentMetadata(t *testing.T) {
+	original := []Message{{
+		Role: "assistant",
+		Content: content.Content{
+			&content.ImageURL{
+				URL:      "https://example.com/image.png",
+				MimeType: "image/png",
+				Metadata: map[string]string{"openai:item_id": "img_1"},
+			},
+			&content.Thought{
+				ID:       "r1",
+				Text:     "thinking",
+				Metadata: map[string]string{"openai:reasoning_format": "anthropic-claude-v1"},
+			},
+		},
+	}}
+
+	cloned := cloneMessages(original)
+	require.Len(t, cloned, 1)
+
+	image, ok := cloned[0].Content[0].(*content.ImageURL)
+	require.True(t, ok)
+	assert.Equal(t, "img_1", image.Metadata["openai:item_id"])
+
+	thought, ok := cloned[0].Content[1].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "anthropic-claude-v1", thought.Metadata["openai:reasoning_format"])
+
+	originalImage := original[0].Content[0].(*content.ImageURL)
+	originalThought := original[0].Content[1].(*content.Thought)
+	originalImage.Metadata["openai:item_id"] = "mutated"
+	originalThought.Metadata["openai:reasoning_format"] = "mutated"
+
+	assert.Equal(t, "img_1", image.Metadata["openai:item_id"])
+	assert.Equal(t, "anthropic-claude-v1", thought.Metadata["openai:reasoning_format"])
+}
+
 func firstText(msg Message) string {
 	for _, item := range msg.Content {
 		if text, ok := item.(*content.Text); ok {

--- a/main.go
+++ b/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -35,6 +39,27 @@ func main() {
 	}
 
 	provider := os.Args[1]
+
+	// gemini-tts is a one-shot TTS flow (no tools, writes a WAV file) that
+	// doesn't fit the chat-loop shape used for the other providers, so it
+	// gets its own entry point.
+	if provider == "gemini-tts" {
+		apiKey := os.Getenv("GEMINI_API_KEY")
+		if apiKey == "" {
+			fmt.Println("Error: GEMINI_API_KEY environment variable is not set")
+			return
+		}
+		prompt := "Say with a cheerful tone: Hello from go-llms! This is Gemini text-to-speech."
+		if len(os.Args) > 2 {
+			prompt = os.Args[2]
+		}
+		if err := runGeminiTTS(apiKey, prompt, "out.wav"); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	var llmProvider llms.Provider
 
 	var cleanup func()
@@ -244,6 +269,8 @@ func printUsage() {
 	fmt.Println("  openrouter-thinking - Same as openrouter but with medium reasoning effort")
 	fmt.Println("                        Optional: pass model as second arg (default: anthropic/claude-sonnet-4)")
 	fmt.Println("  xai                 - Uses xAI's Grok 3 Mini (requires XAI_API_KEY)")
+	fmt.Println("  gemini-tts          - Synthesizes speech to out.wav via Gemini TTS (requires GEMINI_API_KEY)")
+	fmt.Println("                        Optional: pass the prompt as second arg")
 	fmt.Println()
 	fmt.Println("Environment variables can be set directly or loaded from a .env file.")
 	fmt.Println()
@@ -301,3 +328,96 @@ var DoMath = tools.FuncGrammar(
 		return tools.SuccessWithLabel(expr, result)
 	},
 )
+
+// Gemini TTS always streams 24 kHz, 16-bit, mono PCM. The model emits many
+// small chunks (~40 ms each) as base64 data URIs like
+// `data:audio/L16;rate=24000;base64,...`; we concatenate the decoded PCM and
+// wrap it in a WAV container at the end.
+const (
+	ttsSampleRate    = 24000
+	ttsChannels      = 1
+	ttsBitsPerSample = 16
+)
+
+func runGeminiTTS(apiKey, prompt, outPath string) error {
+	provider := google.New("gemini-3.1-flash-tts-preview").
+		WithGeminiAPI(apiKey).
+		WithMaxOutputTokens(0).
+		WithThinking(0).
+		WithModalities("AUDIO").
+		WithSpeechVoice("Kore")
+
+	llm := llms.New(provider)
+
+	start := time.Now()
+	var pcm []byte
+	var mime string
+	chunks := 0
+	for update := range llm.Chat(prompt) {
+		if u, ok := update.(llms.AudioUpdate); ok {
+			b, err := decodeAudioDataURI(u.URL)
+			if err != nil {
+				return fmt.Errorf("decode audio chunk: %w", err)
+			}
+			pcm = append(pcm, b...)
+			if mime == "" {
+				mime = u.MimeType
+			}
+			chunks++
+			fmt.Fprintf(os.Stderr, "[%s] chunk %d arrived (%d bytes, total pcm %d bytes)\n",
+				time.Since(start).Round(time.Millisecond), chunks, len(b), len(pcm))
+		}
+	}
+	if err := llm.Err(); err != nil {
+		return err
+	}
+	if len(pcm) == 0 {
+		return fmt.Errorf("no audio returned")
+	}
+
+	if err := writeWAV(outPath, pcm, ttsSampleRate, ttsChannels, ttsBitsPerSample); err != nil {
+		return fmt.Errorf("write wav: %w", err)
+	}
+
+	durationMs := len(pcm) * 1000 / (ttsSampleRate * ttsChannels * ttsBitsPerSample / 8)
+	dim("[%d chunks, %s PCM, %d ms audio, %s wall]\n",
+		chunks, mime, durationMs, time.Since(start).Round(time.Millisecond))
+	fmt.Printf("Wrote %s\n", outPath)
+	return nil
+}
+
+func decodeAudioDataURI(dataURI string) ([]byte, error) {
+	if !strings.HasPrefix(dataURI, "data:") {
+		return nil, fmt.Errorf("expected data URI, got %q", dataURI)
+	}
+	comma := strings.Index(dataURI, ",")
+	if comma == -1 {
+		return nil, fmt.Errorf("invalid data URI: no comma")
+	}
+	return base64.StdEncoding.DecodeString(dataURI[comma+1:])
+}
+
+func writeWAV(path string, pcm []byte, sampleRate, channels, bitsPerSample uint32) error {
+	var buf bytes.Buffer
+	byteRate := sampleRate * channels * bitsPerSample / 8
+	blockAlign := uint16(channels * bitsPerSample / 8)
+
+	buf.WriteString("RIFF")
+	binary.Write(&buf, binary.LittleEndian, uint32(36+len(pcm)))
+	buf.WriteString("WAVE")
+
+	buf.WriteString("fmt ")
+	binary.Write(&buf, binary.LittleEndian, uint32(16))
+	binary.Write(&buf, binary.LittleEndian, uint16(1)) // PCM
+	binary.Write(&buf, binary.LittleEndian, uint16(channels))
+	binary.Write(&buf, binary.LittleEndian, sampleRate)
+	binary.Write(&buf, binary.LittleEndian, byteRate)
+	binary.Write(&buf, binary.LittleEndian, blockAlign)
+	binary.Write(&buf, binary.LittleEndian, uint16(bitsPerSample))
+
+	buf.WriteString("data")
+	binary.Write(&buf, binary.LittleEndian, uint32(len(pcm)))
+	buf.Write(pcm)
+
+	return os.WriteFile(path, buf.Bytes(), 0644)
+}

--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ func main() {
 			cleanup = func() { wsProvider.Close() }
 		default:
 			llmProvider = openai.New(apiKey, "gpt-5.4").
-				WithThinking(openai.EffortLow).
 				WithVerbosity(openai.VerbosityLow)
 		}
 	case "anthropic":

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/flitsinc/go-llms/content"
@@ -39,11 +40,12 @@ type ChatCompletionsAPI struct {
 
 func NewChatCompletionsAPI(accessToken, model string) *ChatCompletionsAPI {
 	return &ChatCompletionsAPI{
-		accessToken:  accessToken,
-		model:        model,
-		endpoint:     "https://api.openai.com/v1/chat/completions",
-		company:      "OpenAI",
-		includeUsage: true,
+		accessToken:          accessToken,
+		model:                model,
+		endpoint:             "https://api.openai.com/v1/chat/completions",
+		company:              "OpenAI",
+		includeUsage:         true,
+		promptCacheRetention: "24h",
 	}
 }
 
@@ -81,6 +83,13 @@ func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI 
 // This is an OpenAI-specific feature.
 func (m *ChatCompletionsAPI) WithPromptCacheRetention(retention string) *ChatCompletionsAPI {
 	m.promptCacheRetention = retention
+	return m
+}
+
+// WithoutPromptCacheRetention disables prompt_cache_retention even when
+// content contains a long cache hint.
+func (m *ChatCompletionsAPI) WithoutPromptCacheRetention() *ChatCompletionsAPI {
+	m.promptCacheRetention = ""
 	return m
 }
 
@@ -421,6 +430,177 @@ func (s *ChatCompletionsStream) Usage() llms.Usage {
 	}
 }
 
+func (s *ChatCompletionsStream) emitReasoningDetail(
+	rd ReasoningDetail,
+	yield func(llms.StreamStatus) bool,
+) bool {
+	thought, err := s.applyReasoningDetail(rd)
+	if err != nil {
+		s.err = err
+		return false
+	}
+	if thought == nil {
+		return true
+	}
+	s.lastThought = thought
+	return yield(llms.StreamStatusThinking)
+}
+
+func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*content.Thought, error) {
+	aggregate := s.findReasoningThought(rd)
+	if aggregate == nil {
+		aggregate = &content.Thought{ID: rd.ID}
+		s.message.Content = append(s.message.Content, aggregate)
+	} else if aggregate.ID == "" && rd.ID != "" {
+		aggregate.ID = rd.ID
+	}
+	s.mergeReasoningMetadata(aggregate, rd)
+
+	switch rd.Type {
+	case "reasoning.encrypted":
+		if rd.Data == "" {
+			return nil, nil
+		}
+		decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding encrypted reasoning data: %w", err)
+		}
+		aggregate.Encrypted = decodedData
+		aggregate.Text = "(Redacted)"
+		aggregate.Summary = true
+		return &content.Thought{
+			ID:        aggregate.ID,
+			Text:      aggregate.Text,
+			Encrypted: append([]byte(nil), decodedData...),
+			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
+			Summary:   true,
+		}, nil
+	case "reasoning.summary":
+		if rd.Summary == "" && rd.Signature == "" {
+			return nil, nil
+		}
+		aggregate.Summary = true
+		aggregate.Text += rd.Summary
+		if rd.Signature != "" {
+			aggregate.Signature = rd.Signature
+		}
+		return &content.Thought{
+			ID:        aggregate.ID,
+			Text:      rd.Summary,
+			Signature: rd.Signature,
+			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
+			Summary:   true,
+		}, nil
+	default:
+		if rd.Text == "" && rd.Signature == "" {
+			return nil, nil
+		}
+		aggregate.Text += rd.Text
+		if rd.Signature != "" {
+			aggregate.Signature = rd.Signature
+		}
+		return &content.Thought{
+			ID:        aggregate.ID,
+			Text:      rd.Text,
+			Signature: rd.Signature,
+			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
+			Summary:   aggregate.Summary,
+		}, nil
+	}
+}
+
+func (s *ChatCompletionsStream) findReasoningThought(rd ReasoningDetail) *content.Thought {
+	var fallback *content.Thought
+	for i := len(s.message.Content) - 1; i >= 0; i-- {
+		thought, ok := s.message.Content[i].(*content.Thought)
+		if !ok {
+			continue
+		}
+		if rd.ID != "" {
+			if thought.ID == rd.ID {
+				return thought
+			}
+		}
+		if rd.Index != nil {
+			if idx, ok := thoughtReasoningIndex(thought); ok && idx == *rd.Index {
+				return thought
+			}
+		}
+		if fallback == nil && thoughtMatchesReasoningDetail(thought, rd) {
+			fallback = thought
+		}
+	}
+	return fallback
+}
+
+func (s *ChatCompletionsStream) mergeReasoningMetadata(thought *content.Thought, rd ReasoningDetail) {
+	metadata := reasoningDetailMetadata(rd)
+	if len(metadata) == 0 {
+		return
+	}
+	if thought.Metadata == nil {
+		thought.Metadata = metadata
+		return
+	}
+	for k, v := range metadata {
+		thought.Metadata[k] = v
+	}
+}
+
+func reasoningDetailMetadata(rd ReasoningDetail) map[string]string {
+	var metadata map[string]string
+	if rd.Format != "" {
+		metadata = map[string]string{"openai:reasoning_format": rd.Format}
+	}
+	if rd.Index != nil {
+		if metadata == nil {
+			metadata = make(map[string]string, 1)
+		}
+		metadata["openai:reasoning_index"] = strconv.Itoa(*rd.Index)
+	}
+	return metadata
+}
+
+func thoughtReasoningIndex(thought *content.Thought) (int, bool) {
+	if thought == nil || thought.Metadata == nil {
+		return 0, false
+	}
+	val, ok := thought.Metadata["openai:reasoning_index"]
+	if !ok || val == "" {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
+}
+
+func thoughtMatchesReasoningDetail(thought *content.Thought, rd ReasoningDetail) bool {
+	if thought == nil {
+		return false
+	}
+	switch rd.Type {
+	case "reasoning.encrypted":
+		return len(thought.Encrypted) > 0
+	case "reasoning.summary":
+		return thought.Summary && len(thought.Encrypted) == 0
+	default:
+		return !thought.Summary && len(thought.Encrypted) == 0
+	}
+}
+
+func cloneThoughtMetadata(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
 func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) {
 	reader := bufio.NewReader(s.stream)
 	var activeToolCallIndex = -1 // Track the index of the tool call being processed
@@ -529,57 +709,22 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				}
 			}
 			// Handle reasoning/thinking tokens from providers that include them
-			// in the OpenAI-compatible streaming format. Prefer delta.Reasoning
-			// for text; fall back to reasoning_details[].Text if absent.
-			reasoningText := ""
+			// in the OpenAI-compatible streaming format. delta.Reasoning is the
+			// legacy plaintext field; reasoning_details carries structured replay data.
 			if delta.Reasoning != nil && *delta.Reasoning != "" {
-				reasoningText = *delta.Reasoning
-			}
-			if reasoningText == "" {
-				for _, rd := range delta.ReasoningDetails {
-					if rd.Text != "" {
-						reasoningText = rd.Text
-						break
-					}
-				}
-			}
-			if reasoningText != "" {
-				if s.lastThought == nil {
-					s.lastThought = &content.Thought{}
-				}
-				s.lastThought.Text = reasoningText
-				s.message.Content.AppendThought(reasoningText)
-				if !yield(llms.StreamStatusThinking) {
+				if !s.emitReasoningDetail(ReasoningDetail{
+					Type: "reasoning.text",
+					Text: *delta.Reasoning,
+				}, yield) {
 					return
 				}
 			}
-			// Process reasoning_details for signatures and encrypted thinking.
 			for _, rd := range delta.ReasoningDetails {
-				if rd.Signature != "" {
-					// Signature arrives on the final reasoning chunk.
-					if s.lastThought == nil {
-						s.lastThought = &content.Thought{}
-						s.message.Content.AppendThought("")
-					}
-					s.message.Content.SetThoughtSignature(rd.Signature)
-					s.lastThought.Signature = rd.Signature
+				if delta.Reasoning != nil && *delta.Reasoning != "" && rd.Text != "" {
+					rd.Text = ""
 				}
-				if rd.Type == "reasoning.encrypted" && rd.Data != "" {
-					decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
-					if err != nil {
-						s.err = fmt.Errorf("error decoding encrypted reasoning data: %w", err)
-						return
-					}
-					thought := &content.Thought{
-						Text:      "(Redacted)",
-						Encrypted: decodedData,
-						Summary:   true,
-					}
-					s.lastThought = thought
-					s.message.Content = append(s.message.Content, thought)
-					if !yield(llms.StreamStatusThinking) {
-						return
-					}
+				if !s.emitReasoningDetail(rd, yield) {
+					return
 				}
 			}
 

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -31,7 +31,13 @@ type ChatCompletionsAPI struct {
 	// When true, include stream_options.include_usage in requests; default true.
 	includeUsage bool
 
+	// When true, encode CacheHint items as cache_control on content parts.
+	cacheControlPromptHints bool
+	// When true, encode assistant Thought items as reasoning_details for replay.
+	assistantReasoningReplay bool
+
 	customPayloadValues map[string]any
+	customHeaders       map[string]string
 
 	// When set, include prompt_cache_retention in requests that contain a "long"
 	// cache hint. This is an OpenAI-specific feature.
@@ -78,6 +84,21 @@ func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI 
 	return m
 }
 
+// WithCacheControlPromptHints encodes CacheHint items as cache_control on
+// content parts instead of using prompt_cache_retention.
+func (m *ChatCompletionsAPI) WithCacheControlPromptHints() *ChatCompletionsAPI {
+	m.cacheControlPromptHints = true
+	return m
+}
+
+// WithAssistantReasoningReplay encodes assistant Thought items as
+// reasoning_details so they can be replayed on OpenAI-compatible providers
+// that support preserved reasoning continuity.
+func (m *ChatCompletionsAPI) WithAssistantReasoningReplay() *ChatCompletionsAPI {
+	m.assistantReasoningReplay = true
+	return m
+}
+
 // WithPromptCacheRetention enables extended prompt caching with the given
 // retention duration (e.g. "24h") when content contains a "long" cache hint.
 // This is an OpenAI-specific feature.
@@ -105,6 +126,15 @@ func (m *ChatCompletionsAPI) WithCustomPayloadValue(key string, value any) *Chat
 	return m
 }
 
+// WithHeader sets an additional HTTP header on requests made by this client.
+func (m *ChatCompletionsAPI) WithHeader(key, value string) *ChatCompletionsAPI {
+	if m.customHeaders == nil {
+		m.customHeaders = make(map[string]string)
+	}
+	m.customHeaders[key] = value
+	return m
+}
+
 func (m *ChatCompletionsAPI) SetHTTPClient(client *http.Client) {
 	m.httpClient = client
 }
@@ -126,16 +156,21 @@ func (m *ChatCompletionsAPI) BuildPayload(
 	toolbox *tools.Toolbox,
 	jsonOutputSchema *tools.ValueSchema,
 ) (map[string]any, error) {
+	encodingOptions := chatMessageEncodingOptions{
+		cacheControlPromptHints:  m.cacheControlPromptHints,
+		assistantReasoningReplay: m.assistantReasoningReplay,
+	}
+
 	var apiMessages []Message
 	if systemPrompt != nil {
 		apiMessages = append(apiMessages, Message{
 			Role:    "system",
-			Content: ConvertContent(systemPrompt),
+			Content: ConvertContentWithOptions(systemPrompt, encodingOptions),
 		})
 	}
 
 	for _, msg := range messages {
-		convertedMsgs := MessagesFromLLM(msg)
+		convertedMsgs := MessagesFromLLMWithOptions(msg, encodingOptions)
 		apiMessages = append(apiMessages, convertedMsgs...)
 	}
 
@@ -162,7 +197,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 		payload["verbosity"] = m.verbosity
 	}
 
-	if m.promptCacheRetention != "" && hasLongCacheHint(systemPrompt, messages) {
+	if !m.cacheControlPromptHints && m.promptCacheRetention != "" && hasLongCacheHint(systemPrompt, messages) {
 		payload["prompt_cache_retention"] = m.promptCacheRetention
 	}
 
@@ -322,6 +357,9 @@ func (m *ChatCompletionsAPI) DoRequest(ctx context.Context, payload map[string]a
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", m.accessToken))
 	}
 	req.Header.Set("Content-Type", "application/json")
+	for k, v := range m.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	client := m.httpClient
 	if client == nil {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -585,6 +585,9 @@ func (s *ChatCompletionsStream) findReasoningThought(rd ReasoningDetail) *conten
 			if thought.ID == rd.ID {
 				return thought
 			}
+			if thought.ID != "" {
+				continue
+			}
 		}
 		if rd.Index != nil {
 			if idx, ok := thoughtReasoningIndex(thought); ok && idx == *rd.Index {

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -42,13 +42,17 @@ type ChatCompletionsAPI struct {
 	// When set, include prompt_cache_retention in requests that contain a "long"
 	// cache hint. This is an OpenAI-specific feature.
 	promptCacheRetention string
+	// Tracks whether prompt cache retention was explicitly configured by the caller.
+	promptCacheRetentionExplicit bool
 }
+
+const defaultChatCompletionsEndpoint = "https://api.openai.com/v1/chat/completions"
 
 func NewChatCompletionsAPI(accessToken, model string) *ChatCompletionsAPI {
 	return &ChatCompletionsAPI{
 		accessToken:          accessToken,
 		model:                model,
-		endpoint:             "https://api.openai.com/v1/chat/completions",
+		endpoint:             defaultChatCompletionsEndpoint,
 		company:              "OpenAI",
 		includeUsage:         true,
 		promptCacheRetention: "24h",
@@ -104,6 +108,7 @@ func (m *ChatCompletionsAPI) WithAssistantReasoningReplay() *ChatCompletionsAPI 
 // This is an OpenAI-specific feature.
 func (m *ChatCompletionsAPI) WithPromptCacheRetention(retention string) *ChatCompletionsAPI {
 	m.promptCacheRetention = retention
+	m.promptCacheRetentionExplicit = true
 	return m
 }
 
@@ -111,6 +116,7 @@ func (m *ChatCompletionsAPI) WithPromptCacheRetention(retention string) *ChatCom
 // content contains a long cache hint.
 func (m *ChatCompletionsAPI) WithoutPromptCacheRetention() *ChatCompletionsAPI {
 	m.promptCacheRetention = ""
+	m.promptCacheRetentionExplicit = true
 	return m
 }
 
@@ -197,7 +203,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 		payload["verbosity"] = m.verbosity
 	}
 
-	if !m.cacheControlPromptHints && m.promptCacheRetention != "" && hasLongCacheHint(systemPrompt, messages) {
+	if m.shouldSendPromptCacheRetention(systemPrompt, messages) {
 		payload["prompt_cache_retention"] = m.promptCacheRetention
 	}
 
@@ -413,6 +419,19 @@ func (m *ChatCompletionsAPI) DoRequest(ctx context.Context, payload map[string]a
 	return &ChatCompletionsStream{ctx: ctx, model: m.model, stream: resp.Body, debugger: debugger}
 }
 
+func (m *ChatCompletionsAPI) shouldSendPromptCacheRetention(
+	systemPrompt content.Content,
+	messages []llms.Message,
+) bool {
+	if m.cacheControlPromptHints || m.promptCacheRetention == "" || !hasLongCacheHint(systemPrompt, messages) {
+		return false
+	}
+	if m.promptCacheRetentionExplicit {
+		return true
+	}
+	return strings.TrimRight(m.endpoint, "/") == defaultChatCompletionsEndpoint
+}
+
 type ChatCompletionsStream struct {
 	ctx         context.Context
 	model       string
@@ -496,22 +515,30 @@ func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*conte
 
 	switch rd.Type {
 	case "reasoning.encrypted":
-		if rd.Data == "" {
+		if rd.Data == "" && rd.Signature == "" {
 			return nil, nil
 		}
-		decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding encrypted reasoning data: %w", err)
+		var deltaEncrypted []byte
+		if rd.Data != "" {
+			decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding encrypted reasoning data: %w", err)
+			}
+			aggregate.Encrypted = decodedData
+			aggregate.Text = "(Redacted)"
+			aggregate.Summary = true
+			deltaEncrypted = append([]byte(nil), decodedData...)
 		}
-		aggregate.Encrypted = decodedData
-		aggregate.Text = "(Redacted)"
-		aggregate.Summary = true
+		if rd.Signature != "" {
+			aggregate.Signature = rd.Signature
+		}
 		return &content.Thought{
 			ID:        aggregate.ID,
 			Text:      aggregate.Text,
-			Encrypted: append([]byte(nil), decodedData...),
+			Encrypted: deltaEncrypted,
+			Signature: rd.Signature,
 			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
-			Summary:   true,
+			Summary:   aggregate.Summary,
 		}, nil
 	case "reasoning.summary":
 		if rd.Summary == "" && rd.Signature == "" {

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -515,6 +515,44 @@ func TestChatCompletionsStream_ReasoningSummaryDeltaAndAggregate(t *testing.T) {
 	assert.Equal(t, "anthropic-claude-v1", summary.Metadata["openai:reasoning_format"])
 }
 
+func TestChatCompletionsStream_ApplyReasoningDetail_DoesNotMatchDifferentIDByIndex(t *testing.T) {
+	stream := &ChatCompletionsStream{
+		message: llms.Message{
+			Content: content.Content{
+				&content.Thought{
+					ID:       "r1",
+					Text:     "existing",
+					Metadata: map[string]string{"openai:reasoning_index": "0"},
+				},
+			},
+		},
+	}
+
+	thought, err := stream.applyReasoningDetail(ReasoningDetail{
+		Type:  "reasoning.text",
+		ID:    "r2",
+		Index: intPtr(0),
+		Text:  "new",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, thought)
+	assert.Equal(t, "r2", thought.ID)
+	assert.Equal(t, "new", thought.Text)
+
+	require.Len(t, stream.message.Content, 2)
+
+	firstThought, ok := stream.message.Content[0].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "r1", firstThought.ID)
+	assert.Equal(t, "existing", firstThought.Text)
+
+	secondThought, ok := stream.message.Content[1].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "r2", secondThought.ID)
+	assert.Equal(t, "new", secondThought.Text)
+	assert.Equal(t, "0", secondThought.Metadata["openai:reasoning_index"])
+}
+
 func TestBuildPayload_WithCacheControlPromptHintsAndAssistantReasoningReplay(t *testing.T) {
 	m := NewChatCompletionsAPI("", "test-model").
 		WithCacheControlPromptHints().
@@ -614,4 +652,8 @@ func TestDoRequest_WithHeader(t *testing.T) {
 	}
 	require.NoError(t, stream.Err())
 	assert.Equal(t, "https://example.com", gotHeader)
+}
+
+func intPtr(v int) *int {
+	return &v
 }

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -376,13 +376,47 @@ func TestBuildPayload_DefaultPromptCacheRetention(t *testing.T) {
 	require.Equal(t, "24h", payload["prompt_cache_retention"])
 }
 
+func TestBuildPayload_DefaultPromptCacheRetention_NotSentToCustomEndpoint(t *testing.T) {
+	m := NewChatCompletionsAPI("", "gpt-5").
+		WithEndpoint("https://api.groq.com/openai/v1/chat/completions", "Groq")
+	payload, err := m.BuildPayload(
+		content.Content{
+			&content.Text{Text: "Cache this"},
+			&content.CacheHint{Duration: "long"},
+		},
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	_, ok := payload["prompt_cache_retention"]
+	assert.False(t, ok)
+}
+
+func TestBuildPayload_WithPromptCacheRetention_SentToCustomEndpointWhenExplicit(t *testing.T) {
+	m := NewChatCompletionsAPI("", "gpt-5").
+		WithEndpoint("https://api.groq.com/openai/v1/chat/completions", "Groq").
+		WithPromptCacheRetention("24h")
+	payload, err := m.BuildPayload(
+		content.Content{
+			&content.Text{Text: "Cache this"},
+			&content.CacheHint{Duration: "long"},
+		},
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "24h", payload["prompt_cache_retention"])
+}
+
 func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
 	encrypted := base64.StdEncoding.EncodeToString([]byte("encrypted-reasoning"))
 	sse := strings.Join([]string{
 		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
 		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","text":"Hello ","format":"anthropic-claude-v1","index":0}]}}]}`,
 		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","signature":"sig-1","format":"anthropic-claude-v1","index":0}]}}]}`,
-		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.encrypted","id":"r2","data":"` + encrypted + `","format":"anthropic-claude-v1","index":1}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.encrypted","id":"r2","data":"` + encrypted + `","signature":"enc-sig","format":"anthropic-claude-v1","index":1}]}}]}`,
 		`data: {"id":"chat_1","choices":[{"delta":{"content":"Done"}}]}`,
 		`data: [DONE]`,
 		"",
@@ -416,6 +450,7 @@ func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
 	assert.Equal(t, "r2", thoughts[2].ID)
 	assert.Equal(t, "(Redacted)", thoughts[2].Text)
 	assert.Equal(t, []byte("encrypted-reasoning"), thoughts[2].Encrypted)
+	assert.Equal(t, "enc-sig", thoughts[2].Signature)
 	assert.True(t, thoughts[2].Summary)
 	assert.Equal(t, "1", thoughts[2].Metadata["openai:reasoning_index"])
 
@@ -438,6 +473,7 @@ func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
 	assert.Equal(t, "r2", secondThought.ID)
 	assert.Equal(t, "(Redacted)", secondThought.Text)
 	assert.Equal(t, []byte("encrypted-reasoning"), secondThought.Encrypted)
+	assert.Equal(t, "enc-sig", secondThought.Signature)
 	assert.True(t, secondThought.Summary)
 	assert.Equal(t, "1", secondThought.Metadata["openai:reasoning_index"])
 

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -478,3 +478,104 @@ func TestChatCompletionsStream_ReasoningSummaryDeltaAndAggregate(t *testing.T) {
 	assert.True(t, summary.Summary)
 	assert.Equal(t, "anthropic-claude-v1", summary.Metadata["openai:reasoning_format"])
 }
+
+func TestBuildPayload_WithCacheControlPromptHintsAndAssistantReasoningReplay(t *testing.T) {
+	m := NewChatCompletionsAPI("", "test-model").
+		WithCacheControlPromptHints().
+		WithAssistantReasoningReplay()
+
+	payload, err := m.BuildPayload(
+		content.Content{
+			&content.Text{Text: "Cache me"},
+			&content.CacheHint{Duration: "long"},
+		},
+		[]llms.Message{{
+			Role: "assistant",
+			Content: content.Content{
+				&content.Thought{
+					ID:       "t1",
+					Text:     "first",
+					Metadata: map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "0"},
+				},
+				&content.Thought{
+					ID:        "t2",
+					Text:      "(Redacted)",
+					Encrypted: []byte("secret"),
+					Summary:   true,
+					Metadata:  map[string]string{"openai:reasoning_index": "1"},
+				},
+			},
+		}},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+
+	_, hasPromptCacheRetention := raw["prompt_cache_retention"]
+	assert.False(t, hasPromptCacheRetention)
+
+	messages := raw["messages"].([]any)
+	require.Len(t, messages, 2)
+
+	system := messages[0].(map[string]any)
+	systemContent := system["content"].([]any)
+	firstPart := systemContent[0].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, firstPart["cache_control"])
+
+	assistant := messages[1].(map[string]any)
+	reasoningDetails := assistant["reasoning_details"].([]any)
+	require.Len(t, reasoningDetails, 2)
+	assert.Equal(t, "reasoning.text", reasoningDetails[0].(map[string]any)["type"])
+	assert.Equal(t, "reasoning.encrypted", reasoningDetails[1].(map[string]any)["type"])
+}
+
+func TestBuildPayload_AssistantReasoningReplayWithoutVisibleContent(t *testing.T) {
+	m := NewChatCompletionsAPI("", "test-model").WithAssistantReasoningReplay()
+
+	payload, err := m.BuildPayload(nil, []llms.Message{{
+		Role: "assistant",
+		Content: content.Content{
+			&content.Thought{ID: "r1", Text: "thinking"},
+		},
+	}}, nil, nil)
+	require.NoError(t, err)
+
+	messages := payload["messages"].([]Message)
+	require.Len(t, messages, 1)
+	assert.Empty(t, messages[0].Content)
+	require.Len(t, messages[0].ReasoningDetails, 1)
+	assert.Equal(t, "r1", messages[0].ReasoningDetails[0].ID)
+	assert.Equal(t, "thinking", messages[0].ReasoningDetails[0].Text)
+}
+
+func TestDoRequest_WithHeader(t *testing.T) {
+	var gotHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("HTTP-Referer")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	m := NewChatCompletionsAPI("", "test-model").
+		WithEndpoint(ts.URL, "Test").
+		WithHeader("HTTP-Referer", "https://example.com")
+
+	stream := m.DoRequest(context.Background(), map[string]any{
+		"model":    "test-model",
+		"messages": []Message{},
+		"stream":   true,
+	})
+	require.NoError(t, stream.Err())
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+	assert.Equal(t, "https://example.com", gotHeader)
+}

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -2,9 +2,11 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/flitsinc/go-llms/content"
@@ -357,4 +359,122 @@ func TestChatCompletions_ToolChoice_Mapping(t *testing.T) {
 		toolsList := tc["tools"].([]any)
 		require.Len(t, toolsList, 2)
 	})
+}
+
+func TestBuildPayload_DefaultPromptCacheRetention(t *testing.T) {
+	m := NewChatCompletionsAPI("", "gpt-5")
+	payload, err := m.BuildPayload(
+		content.Content{
+			&content.Text{Text: "Cache this"},
+			&content.CacheHint{Duration: "long"},
+		},
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "24h", payload["prompt_cache_retention"])
+}
+
+func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
+	encrypted := base64.StdEncoding.EncodeToString([]byte("encrypted-reasoning"))
+	sse := strings.Join([]string{
+		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","text":"Hello ","format":"anthropic-claude-v1","index":0}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","signature":"sig-1","format":"anthropic-claude-v1","index":0}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.encrypted","id":"r2","data":"` + encrypted + `","format":"anthropic-claude-v1","index":1}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"content":"Done"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+
+	var thoughts []content.Thought
+	var thinkingDone int
+	for status := range stream.Iter() {
+		switch status {
+		case llms.StreamStatusThinking:
+			thoughts = append(thoughts, stream.Thought())
+		case llms.StreamStatusThinkingDone:
+			thinkingDone++
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, thoughts, 3)
+
+	assert.Equal(t, "r1", thoughts[0].ID)
+	assert.Equal(t, "Hello ", thoughts[0].Text)
+	assert.Equal(t, "anthropic-claude-v1", thoughts[0].Metadata["openai:reasoning_format"])
+	assert.Equal(t, "0", thoughts[0].Metadata["openai:reasoning_index"])
+
+	assert.Equal(t, "r1", thoughts[1].ID)
+	assert.Empty(t, thoughts[1].Text)
+	assert.Equal(t, "sig-1", thoughts[1].Signature)
+	assert.Equal(t, "0", thoughts[1].Metadata["openai:reasoning_index"])
+
+	assert.Equal(t, "r2", thoughts[2].ID)
+	assert.Equal(t, "(Redacted)", thoughts[2].Text)
+	assert.Equal(t, []byte("encrypted-reasoning"), thoughts[2].Encrypted)
+	assert.True(t, thoughts[2].Summary)
+	assert.Equal(t, "1", thoughts[2].Metadata["openai:reasoning_index"])
+
+	assert.Equal(t, 1, thinkingDone)
+	assert.Equal(t, "Done", stream.Text())
+
+	msg := stream.Message()
+	require.Len(t, msg.Content, 3)
+
+	firstThought, ok := msg.Content[0].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "r1", firstThought.ID)
+	assert.Equal(t, "Hello ", firstThought.Text)
+	assert.Equal(t, "sig-1", firstThought.Signature)
+	assert.Equal(t, "anthropic-claude-v1", firstThought.Metadata["openai:reasoning_format"])
+	assert.Equal(t, "0", firstThought.Metadata["openai:reasoning_index"])
+
+	secondThought, ok := msg.Content[1].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "r2", secondThought.ID)
+	assert.Equal(t, "(Redacted)", secondThought.Text)
+	assert.Equal(t, []byte("encrypted-reasoning"), secondThought.Encrypted)
+	assert.True(t, secondThought.Summary)
+	assert.Equal(t, "1", secondThought.Metadata["openai:reasoning_index"])
+
+	text, ok := msg.Content[2].(*content.Text)
+	require.True(t, ok)
+	assert.Equal(t, "Done", text.Text)
+}
+
+func TestChatCompletionsStream_ReasoningSummaryDeltaAndAggregate(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.summary","id":"rs1","summary":"Summarized reasoning","format":"anthropic-claude-v1","index":0}]}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+
+	var thoughts []content.Thought
+	for status := range stream.Iter() {
+		if status == llms.StreamStatusThinking {
+			thoughts = append(thoughts, stream.Thought())
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, thoughts, 1)
+	assert.Equal(t, "rs1", thoughts[0].ID)
+	assert.Equal(t, "Summarized reasoning", thoughts[0].Text)
+	assert.True(t, thoughts[0].Summary)
+	assert.Equal(t, "0", thoughts[0].Metadata["openai:reasoning_index"])
+
+	msg := stream.Message()
+	require.Len(t, msg.Content, 1)
+	summary, ok := msg.Content[0].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "rs1", summary.ID)
+	assert.Equal(t, "Summarized reasoning", summary.Text)
+	assert.True(t, summary.Summary)
+	assert.Equal(t, "anthropic-claude-v1", summary.Metadata["openai:reasoning_format"])
 }

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -102,10 +102,11 @@ func (cl *ContentList) UnmarshalJSON(data []byte) error {
 
 // Message represents a chat message in the OpenAI API format.
 type Message struct {
-	Role       string      `json:"role"`
-	Content    ContentList `json:"content,omitempty"`
-	ToolCalls  []toolCall  `json:"tool_calls,omitempty"`
-	ToolCallID string      `json:"tool_call_id,omitempty"`
+	Role             string            `json:"role"`
+	Content          ContentList       `json:"content,omitempty"`
+	ReasoningDetails []ReasoningDetail `json:"reasoning_details,omitempty"`
+	ToolCalls        []toolCall        `json:"tool_calls,omitempty"`
+	ToolCallID       string            `json:"tool_call_id,omitempty"`
 }
 
 // MessagesFromLLM converts an llms.Message to the OpenAI API message format.
@@ -280,12 +281,14 @@ func (t toolCallDelta) ToLLM() llms.ToolCall {
 // ReasoningDetail represents a reasoning token entry from providers that stream
 // thinking via the OpenAI-compatible format (e.g. OpenRouter).
 type ReasoningDetail struct {
-	Type      string `json:"type"`                // "reasoning.text" or "reasoning.encrypted"
+	Type      string `json:"type"`                // "reasoning.summary", "reasoning.text", or "reasoning.encrypted"
+	ID        string `json:"id,omitempty"`        // stable identifier for replaying a logical reasoning block
+	Summary   string `json:"summary,omitempty"`   // summary text for reasoning.summary blocks
 	Text      string `json:"text,omitempty"`      // reasoning text (streamed per chunk)
 	Data      string `json:"data,omitempty"`      // base64-encoded encrypted thinking
 	Signature string `json:"signature,omitempty"` // Anthropic signature (final chunk only)
 	Format    string `json:"format,omitempty"`    // e.g. "anthropic-claude-v1"
-	Index     int    `json:"index,omitempty"`
+	Index     *int   `json:"index,omitempty"`
 }
 
 type chatCompletionDelta struct {

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -43,10 +44,21 @@ type ContentPart struct {
 // ContentList is a list of content parts with custom JSON marshaling.
 type ContentList []ContentPart
 
+type chatMessageEncodingOptions struct {
+	cacheControlPromptHints  bool
+	assistantReasoningReplay bool
+}
+
 // ConvertContent converts content.Content to a ContentList for the OpenAI API.
-// CacheHint items are skipped; use openrouter.ConvertContentWithCacheControl
-// for providers that support cache_control on content parts.
+// CacheHint and Thought items are skipped by default.
 func ConvertContent(c content.Content) ContentList {
+	return ConvertContentWithOptions(c, chatMessageEncodingOptions{})
+}
+
+// ConvertContentWithOptions converts content.Content to a ContentList for the
+// OpenAI-compatible Chat Completions API, with optional provider-specific
+// encodings such as cache_control on content parts.
+func ConvertContentWithOptions(c content.Content, opts chatMessageEncodingOptions) ContentList {
 	cl := make(ContentList, 0, len(c))
 	for _, item := range c {
 		var cp ContentPart
@@ -66,10 +78,14 @@ func ConvertContent(c content.Content) ContentList {
 			text := string(v.Data)
 			cp.Text = &text
 		case *content.Thought:
-			// OpenAI does not expect thinking tokens as input; ignore.
+			// Thoughts are encoded separately as reasoning_details when enabled.
 			continue
 		case *content.CacheHint:
-			// Cache hints are handled at the request level via prompt_cache_retention.
+			if opts.cacheControlPromptHints {
+				if i := len(cl) - 1; i >= 0 {
+					cl[i].CacheControl = &CacheControl{Type: "ephemeral"}
+				}
+			}
 			continue
 		default:
 			panic(fmt.Sprintf("unhandled content item type %T", item))
@@ -112,6 +128,12 @@ type Message struct {
 // MessagesFromLLM converts an llms.Message to the OpenAI API message format.
 // It may return multiple messages if the input is a tool result with auxiliary content.
 func MessagesFromLLM(m llms.Message) []Message {
+	return MessagesFromLLMWithOptions(m, chatMessageEncodingOptions{})
+}
+
+// MessagesFromLLMWithOptions converts an llms.Message to the OpenAI-compatible
+// chat message format with optional provider-specific encodings.
+func MessagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions) []Message {
 	if m.Role == "tool" {
 		var messagesToReturn []Message
 		var primaryResultString string
@@ -145,7 +167,7 @@ func MessagesFromLLM(m llms.Message) []Message {
 		messagesToReturn = append(messagesToReturn, primaryMessage)
 
 		if len(secondaryContent) > 0 {
-			secondaryAPIContent := ConvertContent(secondaryContent)
+			secondaryAPIContent := ConvertContentWithOptions(secondaryContent, opts)
 			if len(secondaryAPIContent) > 0 {
 				secondaryMessage := Message{
 					Role:    "user",
@@ -158,15 +180,20 @@ func MessagesFromLLM(m llms.Message) []Message {
 	}
 
 	apiRole := m.Role
-	apiContent := ConvertContent(m.Content)
+	apiContent := ConvertContentWithOptions(m.Content, opts)
+	var reasoningDetails []ReasoningDetail
+	if opts.assistantReasoningReplay && m.Role == "assistant" {
+		reasoningDetails = reasoningDetailsFromContent(m.Content)
+	}
 
-	if len(apiContent) == 0 && len(m.ToolCalls) == 0 {
+	if len(apiContent) == 0 && len(m.ToolCalls) == 0 && len(reasoningDetails) == 0 {
 		return []Message{}
 	}
 
 	msg := Message{
-		Role:    apiRole,
-		Content: apiContent,
+		Role:             apiRole,
+		Content:          apiContent,
+		ReasoningDetails: reasoningDetails,
 	}
 
 	if m.Role == "assistant" && len(m.ToolCalls) > 0 {
@@ -202,6 +229,41 @@ func MessagesFromLLM(m llms.Message) []Message {
 	}
 
 	return []Message{msg}
+}
+
+func reasoningDetailsFromContent(c content.Content) []ReasoningDetail {
+	var details []ReasoningDetail
+	for _, item := range c {
+		t, ok := item.(*content.Thought)
+		if !ok {
+			continue
+		}
+		detail := ReasoningDetail{
+			ID:        t.ID,
+			Signature: t.Signature,
+		}
+		if format := t.Metadata["openai:reasoning_format"]; format != "" {
+			detail.Format = format
+		}
+		if idx, ok := thoughtReasoningIndex(t); ok {
+			detail.Index = &idx
+		}
+		switch {
+		case len(t.Encrypted) > 0:
+			detail.Type = "reasoning.encrypted"
+			detail.Data = base64.StdEncoding.EncodeToString(t.Encrypted)
+		case t.Summary:
+			detail.Type = "reasoning.summary"
+			detail.Summary = t.Text
+		default:
+			detail.Type = "reasoning.text"
+			detail.Text = t.Text
+		}
+		if detail.Type != "" {
+			details = append(details, detail)
+		}
+	}
+	return details
 }
 
 func normalizeOpenAIToolType(metaType string) string {

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -1,243 +1,26 @@
 package openrouter
 
-import (
-	"context"
-	"encoding/base64"
-	"strconv"
+import "github.com/flitsinc/go-llms/openai"
 
-	"github.com/flitsinc/go-llms/content"
-	"github.com/flitsinc/go-llms/llms"
-	"github.com/flitsinc/go-llms/openai"
-	"github.com/flitsinc/go-llms/tools"
-)
+// Provider is an OpenRouter-configured Chat Completions client.
+type Provider = openai.ChatCompletionsAPI
 
-// Reasoning configures thinking/reasoning behavior for OpenRouter requests.
+// Reasoning configures OpenRouter's top-level reasoning request parameter.
 type Reasoning struct {
 	Effort string `json:"effort,omitempty"` // "xhigh", "high", "medium", "low", "minimal", "none"
 }
 
-// Provider wraps ChatCompletionsAPI with OpenRouter-specific behavior:
-// cache_control on content parts, no prompt_cache_retention, and optional reasoning.
-type Provider struct {
-	*openai.ChatCompletionsAPI
-	reasoning *Reasoning
-}
-
-// New creates an OpenRouter provider.
+// New returns a Chat Completions client configured for OpenRouter.
 func New(apiKey, model string) *Provider {
-	return &Provider{
-		ChatCompletionsAPI: openai.New(apiKey, model).
-			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
-			WithoutPromptCacheRetention(),
-	}
+	return openai.New(apiKey, model).
+		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
+		WithCacheControlPromptHints().
+		WithAssistantReasoningReplay()
 }
 
-// NewWithReasoning creates an OpenRouter provider with reasoning/thinking enabled.
+// NewWithReasoning returns an OpenRouter-configured Chat Completions client
+// with the top-level "reasoning" request parameter set.
 func NewWithReasoning(apiKey, model string, reasoning Reasoning) *Provider {
-	p := New(apiKey, model)
-	p.reasoning = &reasoning
-	return p
+	return New(apiKey, model).
+		WithCustomPayloadValue("reasoning", reasoning)
 }
-
-// Builder method overrides — these delegate to ChatCompletionsAPI but return
-// *Provider so that method chaining doesn't silently downcast to the base type.
-
-func (p *Provider) WithMaxCompletionTokens(n int) *Provider {
-	p.ChatCompletionsAPI.WithMaxCompletionTokens(n)
-	return p
-}
-
-func (p *Provider) WithThinking(effort openai.Effort) *Provider {
-	if p.reasoning == nil {
-		p.reasoning = &Reasoning{}
-	}
-	p.reasoning.Effort = string(effort)
-	return p
-}
-
-func (p *Provider) WithVerbosity(verbosity openai.Verbosity) *Provider {
-	p.ChatCompletionsAPI.WithVerbosity(verbosity)
-	return p
-}
-
-func (p *Provider) WithIncludeUsage(include bool) *Provider {
-	p.ChatCompletionsAPI.WithIncludeUsage(include)
-	return p
-}
-
-func (p *Provider) WithCustomPayloadValue(key string, value any) *Provider {
-	p.ChatCompletionsAPI.WithCustomPayloadValue(key, value)
-	return p
-}
-
-func (p *Provider) Generate(
-	ctx context.Context,
-	systemPrompt content.Content,
-	messages []llms.Message,
-	toolbox *tools.Toolbox,
-	jsonOutputSchema *tools.ValueSchema,
-) llms.ProviderStream {
-	payload, err := p.buildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
-	if err != nil {
-		return &errorStream{err: err}
-	}
-	return p.ChatCompletionsAPI.DoRequest(ctx, payload)
-}
-
-func (p *Provider) buildPayload(
-	systemPrompt content.Content,
-	messages []llms.Message,
-	toolbox *tools.Toolbox,
-	jsonOutputSchema *tools.ValueSchema,
-) (map[string]any, error) {
-	// BuildPayload handles tools, response_format, and other non-message fields.
-	// We rebuild messages below with cache_control and reasoning_details, so the
-	// messages built by BuildPayload are replaced.
-	payload, err := p.ChatCompletionsAPI.BuildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
-	if err != nil {
-		return nil, err
-	}
-
-	// Replace messages with cache_control-aware versions and reasoning continuity.
-	var apiMessages []openai.Message
-	if systemPrompt != nil {
-		apiMessages = append(apiMessages, openai.Message{
-			Role:    "system",
-			Content: convertContentWithCacheControl(systemPrompt),
-		})
-	}
-	for _, msg := range messages {
-		apiMessages = append(apiMessages, messagesWithCacheControl(msg)...)
-	}
-	payload["messages"] = apiMessages
-	delete(payload, "prompt_cache_retention")
-
-	// Add reasoning parameter if configured.
-	if p.reasoning != nil {
-		payload["reasoning"] = p.reasoning
-	}
-
-	return payload, nil
-}
-
-// convertContentWithCacheControl converts content.Content to a ContentList,
-// attaching cache_control: {"type": "ephemeral"} to content parts that precede
-// a CacheHint. This enables prompt caching for Anthropic models via OpenRouter.
-//
-// Note: this walks the original content to find CacheHint positions while
-// tracking which items ConvertContent skips (Thought, CacheHint). If
-// ConvertContent starts skipping new types, this function must be updated.
-func convertContentWithCacheControl(c content.Content) openai.ContentList {
-	cl := openai.ConvertContent(c)
-
-	// Walk through original content to find CacheHint positions and attach
-	// cache_control to the corresponding preceding content part.
-	clIdx := 0
-	for _, item := range c {
-		switch item.(type) {
-		case *content.CacheHint:
-			if clIdx > 0 {
-				cl[clIdx-1].CacheControl = &openai.CacheControl{Type: "ephemeral"}
-			}
-		case *content.Thought:
-			// Skipped by ConvertContent, don't advance index.
-		default:
-			clIdx++
-		}
-	}
-	return cl
-}
-
-// messagesWithCacheControl converts an llms.Message to API messages with
-// cache_control support and reasoning continuity for assistant messages.
-func messagesWithCacheControl(m llms.Message) []openai.Message {
-	msgs := openai.MessagesFromLLM(m)
-
-	// For non-tool messages, re-convert content with cache control.
-	if m.Role != "tool" && len(m.Content) > 0 {
-		for i := range msgs {
-			msgs[i].Content = convertContentWithCacheControl(m.Content)
-		}
-	}
-
-	// For assistant messages, extract thoughts and emit as reasoning_details.
-	if m.Role == "assistant" {
-		details := reasoningDetailsFromContent(m.Content)
-		if len(details) > 0 {
-			for i := range msgs {
-				msgs[i].ReasoningDetails = details
-			}
-		}
-	}
-
-	return msgs
-}
-
-func reasoningDetailsFromContent(c content.Content) []openai.ReasoningDetail {
-	var details []openai.ReasoningDetail
-	for _, item := range c {
-		t, ok := item.(*content.Thought)
-		if !ok {
-			continue
-		}
-		detail := openai.ReasoningDetail{
-			ID:        t.ID,
-			Signature: t.Signature,
-		}
-		if format := t.Metadata["openai:reasoning_format"]; format != "" {
-			detail.Format = format
-		}
-		if idx, ok := thoughtReasoningIndex(t); ok {
-			detail.Index = &idx
-		}
-		switch {
-		case len(t.Encrypted) > 0:
-			detail.Type = "reasoning.encrypted"
-			detail.Data = base64.StdEncoding.EncodeToString(t.Encrypted)
-		case t.Summary:
-			detail.Type = "reasoning.summary"
-			detail.Summary = t.Text
-		default:
-			detail.Type = "reasoning.text"
-			detail.Text = t.Text
-		}
-		if detail.Type == "reasoning.text" || detail.Type == "reasoning.summary" || detail.Type == "reasoning.encrypted" {
-			details = append(details, detail)
-		}
-	}
-	return details
-}
-
-func thoughtReasoningIndex(thought *content.Thought) (int, bool) {
-	if thought == nil || thought.Metadata == nil {
-		return 0, false
-	}
-	val, ok := thought.Metadata["openai:reasoning_index"]
-	if !ok || val == "" {
-		return 0, false
-	}
-	idx, err := strconv.Atoi(val)
-	if err != nil {
-		return 0, false
-	}
-	return idx, true
-}
-
-// errorStream is a minimal ProviderStream that only returns an error.
-type errorStream struct {
-	err error
-}
-
-var _ llms.ProviderStream = (*errorStream)(nil)
-
-func (s *errorStream) Err() error { return s.err }
-func (s *errorStream) Iter() func(yield func(llms.StreamStatus) bool) {
-	return func(func(llms.StreamStatus) bool) {}
-}
-func (s *errorStream) Message() llms.Message    { return llms.Message{} }
-func (s *errorStream) Text() string             { return "" }
-func (s *errorStream) Image() (string, string)  { return "", "" }
-func (s *errorStream) Audio() (string, string)  { return "", "" }
-func (s *errorStream) Thought() content.Thought { return content.Thought{} }
-func (s *errorStream) ToolCall() llms.ToolCall  { return llms.ToolCall{} }
-func (s *errorStream) Usage() llms.Usage        { return llms.Usage{} }

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -3,7 +3,7 @@ package openrouter
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
+	"strconv"
 
 	"github.com/flitsinc/go-llms/content"
 	"github.com/flitsinc/go-llms/llms"
@@ -27,7 +27,8 @@ type Provider struct {
 func New(apiKey, model string) *Provider {
 	return &Provider{
 		ChatCompletionsAPI: openai.New(apiKey, model).
-			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter"),
+			WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
+			WithoutPromptCacheRetention(),
 	}
 }
 
@@ -47,7 +48,10 @@ func (p *Provider) WithMaxCompletionTokens(n int) *Provider {
 }
 
 func (p *Provider) WithThinking(effort openai.Effort) *Provider {
-	p.ChatCompletionsAPI.WithThinking(effort)
+	if p.reasoning == nil {
+		p.reasoning = &Reasoning{}
+	}
+	p.reasoning.Effort = string(effort)
 	return p
 }
 
@@ -73,16 +77,29 @@ func (p *Provider) Generate(
 	toolbox *tools.Toolbox,
 	jsonOutputSchema *tools.ValueSchema,
 ) llms.ProviderStream {
+	payload, err := p.buildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
+	if err != nil {
+		return &errorStream{err: err}
+	}
+	return p.ChatCompletionsAPI.DoRequest(ctx, payload)
+}
+
+func (p *Provider) buildPayload(
+	systemPrompt content.Content,
+	messages []llms.Message,
+	toolbox *tools.Toolbox,
+	jsonOutputSchema *tools.ValueSchema,
+) (map[string]any, error) {
 	// BuildPayload handles tools, response_format, and other non-message fields.
 	// We rebuild messages below with cache_control and reasoning_details, so the
 	// messages built by BuildPayload are replaced.
 	payload, err := p.ChatCompletionsAPI.BuildPayload(systemPrompt, messages, toolbox, jsonOutputSchema)
 	if err != nil {
-		return &errorStream{err: err}
+		return nil, err
 	}
 
 	// Replace messages with cache_control-aware versions and reasoning continuity.
-	var apiMessages []any
+	var apiMessages []openai.Message
 	if systemPrompt != nil {
 		apiMessages = append(apiMessages, openai.Message{
 			Role:    "system",
@@ -93,13 +110,14 @@ func (p *Provider) Generate(
 		apiMessages = append(apiMessages, messagesWithCacheControl(msg)...)
 	}
 	payload["messages"] = apiMessages
+	delete(payload, "prompt_cache_retention")
 
 	// Add reasoning parameter if configured.
 	if p.reasoning != nil {
 		payload["reasoning"] = p.reasoning
 	}
 
-	return p.ChatCompletionsAPI.DoRequest(ctx, payload)
+	return payload, nil
 }
 
 // convertContentWithCacheControl converts content.Content to a ContentList,
@@ -130,34 +148,9 @@ func convertContentWithCacheControl(c content.Content) openai.ContentList {
 	return cl
 }
 
-// messageWithReasoning wraps a base message and adds reasoning_details.
-// It uses custom JSON marshaling to preserve all base message fields.
-type messageWithReasoning struct {
-	base             openai.Message
-	reasoningDetails []openai.ReasoningDetail
-}
-
-func (m messageWithReasoning) MarshalJSON() ([]byte, error) {
-	// Marshal base message to a map, then add reasoning_details.
-	data, err := json.Marshal(m.base)
-	if err != nil {
-		return nil, err
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, err
-	}
-	rd, err := json.Marshal(m.reasoningDetails)
-	if err != nil {
-		return nil, err
-	}
-	obj["reasoning_details"] = rd
-	return json.Marshal(obj)
-}
-
 // messagesWithCacheControl converts an llms.Message to API messages with
 // cache_control support and reasoning continuity for assistant messages.
-func messagesWithCacheControl(m llms.Message) []any {
+func messagesWithCacheControl(m llms.Message) []openai.Message {
 	msgs := openai.MessagesFromLLM(m)
 
 	// For non-tool messages, re-convert content with cache control.
@@ -169,55 +162,65 @@ func messagesWithCacheControl(m llms.Message) []any {
 
 	// For assistant messages, extract thoughts and emit as reasoning_details.
 	if m.Role == "assistant" {
-		var details []openai.ReasoningDetail
-		var thoughtText string
-		var signature string
-		for _, item := range m.Content {
-			t, ok := item.(*content.Thought)
-			if !ok {
-				continue
-			}
-			if len(t.Encrypted) > 0 {
-				// Encrypted/redacted thinking — emit as reasoning.encrypted.
-				details = append(details, openai.ReasoningDetail{
-					Type: "reasoning.encrypted",
-					Data: base64.StdEncoding.EncodeToString(t.Encrypted),
-				})
-			} else {
-				thoughtText += t.Text
-				if t.Signature != "" {
-					signature = t.Signature
-				}
-			}
-		}
-		if thoughtText != "" || signature != "" {
-			detail := openai.ReasoningDetail{
-				Type: "reasoning.text",
-				Text: thoughtText,
-			}
-			if signature != "" {
-				detail.Signature = signature
-			}
-			details = append(details, detail)
-		}
+		details := reasoningDetailsFromContent(m.Content)
 		if len(details) > 0 {
-			result := make([]any, len(msgs))
-			for i, msg := range msgs {
-				result[i] = messageWithReasoning{
-					base:             msg,
-					reasoningDetails: details,
-				}
+			for i := range msgs {
+				msgs[i].ReasoningDetails = details
 			}
-			return result
 		}
 	}
 
-	// Default: return as-is
-	result := make([]any, len(msgs))
-	for i, msg := range msgs {
-		result[i] = msg
+	return msgs
+}
+
+func reasoningDetailsFromContent(c content.Content) []openai.ReasoningDetail {
+	var details []openai.ReasoningDetail
+	for _, item := range c {
+		t, ok := item.(*content.Thought)
+		if !ok {
+			continue
+		}
+		detail := openai.ReasoningDetail{
+			ID:        t.ID,
+			Signature: t.Signature,
+		}
+		if format := t.Metadata["openai:reasoning_format"]; format != "" {
+			detail.Format = format
+		}
+		if idx, ok := thoughtReasoningIndex(t); ok {
+			detail.Index = &idx
+		}
+		switch {
+		case len(t.Encrypted) > 0:
+			detail.Type = "reasoning.encrypted"
+			detail.Data = base64.StdEncoding.EncodeToString(t.Encrypted)
+		case t.Summary:
+			detail.Type = "reasoning.summary"
+			detail.Summary = t.Text
+		default:
+			detail.Type = "reasoning.text"
+			detail.Text = t.Text
+		}
+		if detail.Type == "reasoning.text" || detail.Type == "reasoning.summary" || detail.Type == "reasoning.encrypted" {
+			details = append(details, detail)
+		}
 	}
-	return result
+	return details
+}
+
+func thoughtReasoningIndex(thought *content.Thought) (int, bool) {
+	if thought == nil || thought.Metadata == nil {
+		return 0, false
+	}
+	val, ok := thought.Metadata["openai:reasoning_index"]
+	if !ok || val == "" {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
 }
 
 // errorStream is a minimal ProviderStream that only returns an error.
@@ -225,12 +228,16 @@ type errorStream struct {
 	err error
 }
 
-func (s *errorStream) Err() error                                    { return s.err }
-func (s *errorStream) Iter() func(yield func(llms.StreamStatus) bool) { return func(func(llms.StreamStatus) bool) {} }
-func (s *errorStream) Message() llms.Message                         { return llms.Message{} }
-func (s *errorStream) Text() string                                  { return "" }
-func (s *errorStream) Image() (string, string)                       { return "", "" }
-func (s *errorStream) Audio() (string, string)                       { return "", "" }
-func (s *errorStream) Thought() content.Thought                      { return content.Thought{} }
-func (s *errorStream) ToolCall() llms.ToolCall                       { return llms.ToolCall{} }
-func (s *errorStream) Usage() llms.Usage                             { return llms.Usage{} }
+var _ llms.ProviderStream = (*errorStream)(nil)
+
+func (s *errorStream) Err() error { return s.err }
+func (s *errorStream) Iter() func(yield func(llms.StreamStatus) bool) {
+	return func(func(llms.StreamStatus) bool) {}
+}
+func (s *errorStream) Message() llms.Message    { return llms.Message{} }
+func (s *errorStream) Text() string             { return "" }
+func (s *errorStream) Image() (string, string)  { return "", "" }
+func (s *errorStream) Audio() (string, string)  { return "", "" }
+func (s *errorStream) Thought() content.Thought { return content.Thought{} }
+func (s *errorStream) ToolCall() llms.ToolCall  { return llms.ToolCall{} }
+func (s *errorStream) Usage() llms.Usage        { return llms.Usage{} }

--- a/openrouter/openrouter_test.go
+++ b/openrouter/openrouter_test.go
@@ -1,0 +1,156 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasoningDetailsFromContent_PreservesOrderAndMetadata(t *testing.T) {
+	details := reasoningDetailsFromContent(content.Content{
+		&content.Thought{
+			ID:       "t1",
+			Text:     "first",
+			Metadata: map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "0"},
+		},
+		&content.Thought{
+			ID:        "t2",
+			Text:      "(Redacted)",
+			Encrypted: []byte("secret"),
+			Summary:   true,
+			Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "1"},
+		},
+		&content.Thought{
+			ID:        "t3",
+			Text:      "third",
+			Signature: "sig-3",
+			Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "2"},
+		},
+	})
+
+	require.Len(t, details, 3)
+	require.NotNil(t, details[0].Index)
+	require.NotNil(t, details[1].Index)
+	require.NotNil(t, details[2].Index)
+
+	assert.Equal(t, "reasoning.text", details[0].Type)
+	assert.Equal(t, "t1", details[0].ID)
+	assert.Equal(t, "first", details[0].Text)
+	assert.Equal(t, "anthropic-claude-v1", details[0].Format)
+	assert.Equal(t, 0, *details[0].Index)
+
+	assert.Equal(t, "reasoning.encrypted", details[1].Type)
+	assert.Equal(t, "t2", details[1].ID)
+	assert.NotEmpty(t, details[1].Data)
+	assert.Equal(t, "anthropic-claude-v1", details[1].Format)
+	assert.Equal(t, 1, *details[1].Index)
+
+	assert.Equal(t, "reasoning.text", details[2].Type)
+	assert.Equal(t, "t3", details[2].ID)
+	assert.Equal(t, "third", details[2].Text)
+	assert.Equal(t, "sig-3", details[2].Signature)
+	assert.Equal(t, "anthropic-claude-v1", details[2].Format)
+	assert.Equal(t, 2, *details[2].Index)
+}
+
+func TestProviderGenerate_UsesOpenRouterFields(t *testing.T) {
+	p := NewWithReasoning("", "anthropic/claude-sonnet-4", Reasoning{Effort: "medium"})
+
+	payload, err := p.buildPayload(
+		content.Content{
+			&content.Text{Text: "Cache me"},
+			&content.CacheHint{Duration: "long"},
+		},
+		[]llms.Message{{
+			Role: "assistant",
+			Content: content.Content{
+				&content.Thought{
+					ID:       "t1",
+					Text:     "first",
+					Metadata: map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "0"},
+				},
+				&content.Thought{
+					ID:        "t2",
+					Text:      "(Redacted)",
+					Encrypted: []byte("secret"),
+					Summary:   true,
+					Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "1"},
+				},
+				&content.Thought{
+					ID:        "t3",
+					Text:      "third",
+					Signature: "sig-3",
+					Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "2"},
+				},
+				&content.Text{Text: "Need tool output"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+
+	_, hasPromptCacheRetention := raw["prompt_cache_retention"]
+	assert.False(t, hasPromptCacheRetention)
+
+	reasoning, ok := raw["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "medium", reasoning["effort"])
+
+	messages, ok := raw["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, messages, 2)
+
+	systemMessage := messages[0].(map[string]any)
+	systemContent := systemMessage["content"].([]any)
+	firstPart := systemContent[0].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, firstPart["cache_control"])
+
+	assistantMessage := messages[1].(map[string]any)
+	reasoningDetails := assistantMessage["reasoning_details"].([]any)
+	require.Len(t, reasoningDetails, 3)
+
+	first := reasoningDetails[0].(map[string]any)
+	assert.Equal(t, "reasoning.text", first["type"])
+	assert.Equal(t, "first", first["text"])
+	assert.Equal(t, "t1", first["id"])
+
+	second := reasoningDetails[1].(map[string]any)
+	assert.Equal(t, "reasoning.encrypted", second["type"])
+	assert.Equal(t, "t2", second["id"])
+	assert.NotEmpty(t, second["data"])
+
+	third := reasoningDetails[2].(map[string]any)
+	assert.Equal(t, "reasoning.text", third["type"])
+	assert.Equal(t, "third", third["text"])
+	assert.Equal(t, "sig-3", third["signature"])
+	assert.Equal(t, "t3", third["id"])
+}
+
+func TestReasoningDetailsFromContent_SummaryThoughtsBecomeReasoningSummary(t *testing.T) {
+	details := reasoningDetailsFromContent(content.Content{
+		&content.Thought{
+			ID:       "summary_1",
+			Text:     "summary text",
+			Summary:  true,
+			Metadata: map[string]string{"openai:reasoning_index": "3"},
+		},
+	})
+
+	require.Len(t, details, 1)
+	assert.Equal(t, "reasoning.summary", details[0].Type)
+	assert.Equal(t, "summary_1", details[0].ID)
+	assert.Equal(t, "summary text", details[0].Summary)
+	require.NotNil(t, details[0].Index)
+	assert.Equal(t, 3, *details[0].Index)
+}

--- a/openrouter/openrouter_test.go
+++ b/openrouter/openrouter_test.go
@@ -10,57 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReasoningDetailsFromContent_PreservesOrderAndMetadata(t *testing.T) {
-	details := reasoningDetailsFromContent(content.Content{
-		&content.Thought{
-			ID:       "t1",
-			Text:     "first",
-			Metadata: map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "0"},
-		},
-		&content.Thought{
-			ID:        "t2",
-			Text:      "(Redacted)",
-			Encrypted: []byte("secret"),
-			Summary:   true,
-			Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "1"},
-		},
-		&content.Thought{
-			ID:        "t3",
-			Text:      "third",
-			Signature: "sig-3",
-			Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "2"},
-		},
-	})
+func TestNew_BuildPayload_UsesOpenRouterEncoding(t *testing.T) {
+	p := New("", "anthropic/claude-sonnet-4")
 
-	require.Len(t, details, 3)
-	require.NotNil(t, details[0].Index)
-	require.NotNil(t, details[1].Index)
-	require.NotNil(t, details[2].Index)
-
-	assert.Equal(t, "reasoning.text", details[0].Type)
-	assert.Equal(t, "t1", details[0].ID)
-	assert.Equal(t, "first", details[0].Text)
-	assert.Equal(t, "anthropic-claude-v1", details[0].Format)
-	assert.Equal(t, 0, *details[0].Index)
-
-	assert.Equal(t, "reasoning.encrypted", details[1].Type)
-	assert.Equal(t, "t2", details[1].ID)
-	assert.NotEmpty(t, details[1].Data)
-	assert.Equal(t, "anthropic-claude-v1", details[1].Format)
-	assert.Equal(t, 1, *details[1].Index)
-
-	assert.Equal(t, "reasoning.text", details[2].Type)
-	assert.Equal(t, "t3", details[2].ID)
-	assert.Equal(t, "third", details[2].Text)
-	assert.Equal(t, "sig-3", details[2].Signature)
-	assert.Equal(t, "anthropic-claude-v1", details[2].Format)
-	assert.Equal(t, 2, *details[2].Index)
-}
-
-func TestProviderGenerate_UsesOpenRouterFields(t *testing.T) {
-	p := NewWithReasoning("", "anthropic/claude-sonnet-4", Reasoning{Effort: "medium"})
-
-	payload, err := p.buildPayload(
+	payload, err := p.BuildPayload(
 		content.Content{
 			&content.Text{Text: "Cache me"},
 			&content.CacheHint{Duration: "long"},
@@ -103,10 +56,6 @@ func TestProviderGenerate_UsesOpenRouterFields(t *testing.T) {
 	_, hasPromptCacheRetention := raw["prompt_cache_retention"]
 	assert.False(t, hasPromptCacheRetention)
 
-	reasoning, ok := raw["reasoning"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "medium", reasoning["effort"])
-
 	messages, ok := raw["messages"].([]any)
 	require.True(t, ok)
 	require.Len(t, messages, 2)
@@ -137,20 +86,19 @@ func TestProviderGenerate_UsesOpenRouterFields(t *testing.T) {
 	assert.Equal(t, "t3", third["id"])
 }
 
-func TestReasoningDetailsFromContent_SummaryThoughtsBecomeReasoningSummary(t *testing.T) {
-	details := reasoningDetailsFromContent(content.Content{
-		&content.Thought{
-			ID:       "summary_1",
-			Text:     "summary text",
-			Summary:  true,
-			Metadata: map[string]string{"openai:reasoning_index": "3"},
-		},
-	})
+func TestNewWithReasoning_AddsReasoningPayload(t *testing.T) {
+	p := NewWithReasoning("", "anthropic/claude-sonnet-4", Reasoning{Effort: "medium"})
 
-	require.Len(t, details, 1)
-	assert.Equal(t, "reasoning.summary", details[0].Type)
-	assert.Equal(t, "summary_1", details[0].ID)
-	assert.Equal(t, "summary text", details[0].Summary)
-	require.NotNil(t, details[0].Index)
-	assert.Equal(t, 3, *details[0].Index)
+	payload, err := p.BuildPayload(nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+
+	reasoning, ok := raw["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "medium", reasoning["effort"])
 }


### PR DESCRIPTION
## What changed

This refactors the OpenRouter work so preserved reasoning, cache hints, and related replay state live in the shared Chat Completions path instead of a separate OpenRouter payload/stream implementation.

Key changes:
- extend `content.Thought` and related cloning paths so replay-critical metadata survives multiple turns
- keep Chat Completions parsing shared, including reasoning deltas / `reasoning_details`
- add explicit Chat Completions settings for:
  - part-level cache hint encoding (`cache_control`)
  - assistant reasoning replay via `reasoning_details`
  - custom request headers
- reduce `openrouter.New()` to a thin convenience constructor over `openai.ChatCompletionsAPI`
- keep OpenRouter-specific request extras available through `WithCustomPayloadValue(...)`
- expand tests around cache behavior, reasoning replay, and OpenRouter shortcut behavior

## Why

The previous OpenRouter-specific path worked for some cases, but it duplicated request construction and made reasoning replay more fragile than it needed to be.

This branch moves toward a single OpenAI-compatible Chat Completions implementation that can preserve the superset of transcript state needed for multi-turn conversations, while still allowing provider-specific request settings when the wire format genuinely differs.

## Impact

- OpenRouter multi-turn reasoning replay now uses the shared Chat Completions path instead of a separate payload builder.
- `openrouter.New()` still exists, but it is now effectively a clean shortcut for creating an OpenRouter-configured Chat Completions client.
- OpenAI behavior also improves because the shared parser and transcript model now preserve more reasoning metadata cleanly.

## Root cause addressed

The earlier design split OpenRouter request construction away from the shared Chat Completions encoder. That made the OpenRouter path harder to follow, easier to regress, and more likely to drift from the shared parser/state model.

## Validation

- `mise exec go@1.25 -- env GOCACHE=/tmp/go-build go test ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared OpenAI-compatible chat-completions request/streaming path (payload encoding, caching behavior, and reasoning parsing), which could affect multiple providers’ runtime behavior. Added safeguards via new unit tests, but behavior changes around prompt caching and reasoning aggregation warrant careful review.
> 
> **Overview**
> Unifies OpenRouter behavior with the shared `openai.ChatCompletionsAPI` by moving **cache-hint encoding** (via `cache_control` on content parts) and **assistant reasoning replay** (via `reasoning_details`) into the core Chat Completions encoder/stream parser, then reducing `openrouter.New()` to a thin configuration wrapper.
> 
> Extends `content.Thought` (and cloning in `llms` before-response hooks) to carry and preserve provider-prefixed metadata needed for multi-turn reasoning continuity, and adds richer reasoning streaming support (IDs, indexes, summaries, encrypted blocks) with aggregation into `content.Thought` items.
> 
> Updates Chat Completions client configurability and defaults: adds per-request custom headers, introduces a default `prompt_cache_retention` of `24h` *only* for the real OpenAI endpoint (unless explicitly set), and adds tests covering caching rules, header injection, OpenRouter encoding, and reasoning replay parsing. Also adds a `gemini-tts` CLI mode that streams Gemini audio chunks and writes a WAV file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92fe258dfc209f7de8926556bd30fbede516a011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->