### PR TITLE
fix(openrouter): implement Audio() on errorStream

### DIFF
--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -230,6 +230,7 @@ func (s *errorStream) Iter() func(yield func(llms.StreamStatus) bool) { return f
 func (s *errorStream) Message() llms.Message                         { return llms.Message{} }
 func (s *errorStream) Text() string                                  { return "" }
 func (s *errorStream) Image() (string, string)                       { return "", "" }
+func (s *errorStream) Audio() (string, string)                       { return "", "" }
 func (s *errorStream) Thought() content.Thought                      { return content.Thought{} }
 func (s *errorStream) ToolCall() llms.ToolCall                       { return llms.ToolCall{} }
 func (s *errorStream) Usage() llms.Usage                             { return llms.Usage{} }


### PR DESCRIPTION
\`llms.ProviderStream\` was extended with \`Audio() (string, string)\` but \`openrouter.Provider\`'s internal \`errorStream\` wasn't updated. The package currently fails to compile for anyone importing it (line 81: \`&errorStream{...}\` cannot satisfy \`llms.ProviderStream\`). This adds the missing one-liner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, interface-conformance fix that only adds a stub method returning empty values; minimal behavioral impact.
> 
> **Overview**
> Updates OpenRouter’s internal `errorStream` to implement the newly-added `Audio() (string, string)` method on `llms.ProviderStream`, ensuring `openrouter.Provider.Generate` can return `&errorStream{...}` without breaking interface conformance.
> 
> No behavior changes beyond returning empty audio values on error streams; this is a compatibility/compile fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f871188fdae6e7fcedff2b8e8a6cec7fb8c4bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->