### PR TITLE
feat(openai): WithExtraHeader on ChatCompletionsAPI

### DIFF
--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -32,6 +32,9 @@ type ChatCompletionsAPI struct {
 
 	customPayloadValues map[string]any
 
+	// extraHeaders are added to every outgoing request. Set via WithExtraHeader.
+	extraHeaders http.Header
+
 	// When set, include prompt_cache_retention in requests that contain a "long"
 	// cache hint. This is an OpenAI-specific feature.
 	promptCacheRetention string
@@ -93,6 +96,20 @@ func (m *ChatCompletionsAPI) WithCustomPayloadValue(key string, value any) *Chat
 		m.customPayloadValues = make(map[string]any)
 	}
 	m.customPayloadValues[key] = value
+	return m
+}
+
+// WithExtraHeader adds a header that is sent on every outgoing request.
+// Use this for provider-specific headers not covered by other methods
+// (e.g. `x-anthropic-beta` on OpenRouter requests routed to Anthropic).
+// Calling this multiple times with the same key overwrites the previous
+// value; Authorization and Content-Type are set by DoRequest and cannot
+// be overridden here.
+func (m *ChatCompletionsAPI) WithExtraHeader(key, value string) *ChatCompletionsAPI {
+	if m.extraHeaders == nil {
+		m.extraHeaders = http.Header{}
+	}
+	m.extraHeaders.Set(key, value)
 	return m
 }
 
@@ -308,6 +325,11 @@ func (m *ChatCompletionsAPI) DoRequest(ctx context.Context, payload map[string]a
 	req, err := http.NewRequestWithContext(ctx, "POST", m.endpoint, bytes.NewReader(jsonData))
 	if err != nil {
 		return &ChatCompletionsStream{err: fmt.Errorf("error creating request: %w", err)}
+	}
+	for k, vs := range m.extraHeaders {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 	if m.accessToken != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", m.accessToken))

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -358,3 +358,52 @@ func TestChatCompletions_ToolChoice_Mapping(t *testing.T) {
 		require.Len(t, toolsList, 2)
 	})
 }
+
+func TestChatCompletions_WithExtraHeader(t *testing.T) {
+	// Verify that WithExtraHeader-configured values are sent on the HTTP
+	// request. Used for provider-specific headers like `x-anthropic-beta`
+	// on OpenRouter requests routed to Anthropic.
+	headerCh := make(chan http.Header, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerCh <- r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	m := NewChatCompletionsAPI("", "gpt-4o")
+	m.WithEndpoint(ts.URL, "Test")
+	m.WithExtraHeader("X-Anthropic-Beta", "fine-grained-tool-streaming-2025-05-14")
+	m.WithExtraHeader("X-Custom", "value")
+
+	stream := m.Generate(context.Background(), nil, nil, nil, nil)
+	require.NoError(t, stream.Err())
+	hdr := <-headerCh
+	assert.Equal(t, "fine-grained-tool-streaming-2025-05-14", hdr.Get("X-Anthropic-Beta"))
+	assert.Equal(t, "value", hdr.Get("X-Custom"))
+	// Authorization and Content-Type continue to be set by DoRequest.
+	assert.Equal(t, "application/json", hdr.Get("Content-Type"))
+}
+
+func TestChatCompletions_WithExtraHeader_CannotOverrideProtected(t *testing.T) {
+	// Content-Type is set explicitly by DoRequest after extraHeaders are
+	// applied, so a caller cannot override it via WithExtraHeader — this
+	// is intentional: the Messages body is always JSON.
+	headerCh := make(chan http.Header, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerCh <- r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	m := NewChatCompletionsAPI("", "gpt-4o")
+	m.WithEndpoint(ts.URL, "Test")
+	m.WithExtraHeader("Content-Type", "text/plain")
+
+	_ = m.Generate(context.Background(), nil, nil, nil, nil)
+	hdr := <-headerCh
+	assert.Equal(t, "application/json", hdr.Get("Content-Type"))
+}

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -66,6 +66,11 @@ func (p *Provider) WithCustomPayloadValue(key string, value any) *Provider {
 	return p
 }
 
+func (p *Provider) WithExtraHeader(key, value string) *Provider {
+	p.ChatCompletionsAPI.WithExtraHeader(key, value)
+	return p
+}
+
 func (p *Provider) Generate(
 	ctx context.Context,
 	systemPrompt content.Content,


### PR DESCRIPTION
## Summary

Adds \`WithExtraHeader(key, value string)\` to \`openai.ChatCompletionsAPI\` — symmetric to the existing \`WithCustomPayloadValue\` but for HTTP headers.

Needed so wrapper providers (\`openrouter.Provider\`) can forward provider-specific headers. The immediate use case is enabling Anthropic's fine-grained tool streaming beta (\`x-anthropic-beta: fine-grained-tool-streaming-2025-05-14\`) on OpenRouter requests that route to Anthropic — without the header, OpenRouter emits tool_use arguments as a single block instead of streaming deltas.

Also adds the matching override on \`openrouter.Provider\` so chained calls keep the \`*Provider\` type (avoids silent downcast, same pattern as the other builder overrides).

## Design

- \`extraHeaders\` are applied *before* \`Authorization\` and \`Content-Type\` are set via \`Header.Set()\`, so callers cannot override protected headers.
- Follows the same store-and-apply-at-send-time pattern as \`anthropic.Model.WithBeta\`.

## Test plan

- Two new tests in \`openai/chatcompletions_test.go\`:
  - \`WithExtraHeader\` values reach the outgoing request.
  - \`Content-Type\` cannot be overridden.
- Full suite passes: \`go test ./...\` green across all packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small additive change to request construction plus focused tests; main impact is altered HTTP headers on outgoing requests when explicitly configured.
> 
> **Overview**
> Adds `ChatCompletionsAPI.WithExtraHeader()` to persist arbitrary caller-specified HTTP headers and apply them to every outgoing request.
> 
> Updates request sending to merge these headers *before* setting `Authorization` and `Content-Type`, preventing overrides of those protected headers, and exposes the same builder on `openrouter.Provider` to preserve fluent chaining.
> 
> Adds tests verifying extra headers are forwarded and that `Content-Type` cannot be overridden via `WithExtraHeader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf6cfcef909cadec5346e757f6f8029654602c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->