### PR TITLE
Add Gemini image aspect ratio config

### DIFF
--- a/google/gemini3_test.go
+++ b/google/gemini3_test.go
@@ -45,6 +45,14 @@ func TestGemini3Config(t *testing.T) {
 			t.Errorf("expected mediaResolution 'MEDIA_RESOLUTION_HIGH', got %v", genConfig["mediaResolution"])
 		}
 
+		imageConfig, ok := genConfig["imageConfig"].(map[string]any)
+		if !ok {
+			t.Fatal("imageConfig missing or invalid")
+		}
+		if aspectRatio, ok := imageConfig["aspectRatio"].(string); !ok || aspectRatio != "16:9" {
+			t.Errorf("expected image aspect ratio '16:9', got %v", imageConfig["aspectRatio"])
+		}
+
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"candidates": [{"content": {"parts": [{"text": "done"}]}}]}`))
 	}))
@@ -54,7 +62,8 @@ func TestGemini3Config(t *testing.T) {
 	model := New("gemini-3-pro-preview").
 		WithGeminiAPI("fake-key").
 		WithThinkingLevel(ThinkingLevelHigh).
-		WithMediaResolution(MediaResolutionHigh)
+		WithMediaResolution(MediaResolutionHigh).
+		WithImageAspectRatio("16:9")
 	model.SetHTTPClient(client)
 
 	// Override endpoint to point to test server

--- a/google/google.go
+++ b/google/google.go
@@ -82,20 +82,21 @@ func sanitizeSchemaForGemini(schema *tools.ValueSchema) {
 }
 
 type Model struct {
-	tokenSource     oauth2.TokenSource
-	model           string
-	endpoint        string
-	maxOutputTokens int
-	temperature     float64
-	topK            int
-	topP            float64
-	includeThoughts bool
-	thinkingBudget  int
-	thinkingLevel   ThinkingLevel
-	mediaResolution MediaResolution
-	modalities      []string
-	speechVoice     string
-	httpClient      *http.Client
+	tokenSource      oauth2.TokenSource
+	model            string
+	endpoint         string
+	maxOutputTokens  int
+	temperature      float64
+	topK             int
+	topP             float64
+	includeThoughts  bool
+	thinkingBudget   int
+	thinkingLevel    ThinkingLevel
+	mediaResolution  MediaResolution
+	modalities       []string
+	speechVoice      string
+	imageAspectRatio string
+	httpClient       *http.Client
 
 	// streamFunctionCallArguments enables streaming of function call arguments
 	// on Vertex AI Gemini 3+ models. When true, the backend sends partial argument
@@ -202,6 +203,13 @@ func (m *Model) WithModalities(modalities ...string) *Model {
 // Example voices: "Kore", "Puck", "Charon", "Zephyr", "Fenrir".
 func (m *Model) WithSpeechVoice(voice string) *Model {
 	m.speechVoice = voice
+	return m
+}
+
+// WithImageAspectRatio configures Gemini image output aspect ratio.
+// Use with image-output models and WithModalities("IMAGE", "TEXT").
+func (m *Model) WithImageAspectRatio(aspectRatio string) *Model {
+	m.imageAspectRatio = aspectRatio
 	return m
 }
 
@@ -361,6 +369,12 @@ func (m *Model) Generate(
 					"voiceName": m.speechVoice,
 				},
 			},
+		}
+	}
+
+	if m.imageAspectRatio != "" {
+		generationConfig["imageConfig"] = map[string]any{
+			"aspectRatio": m.imageAspectRatio,
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add google.Model.WithImageAspectRatio for Gemini image-output models
- write generationConfig.imageConfig.aspectRatio directly in the Google provider request payload
- cover the generated imageConfig payload in the Gemini config test

## Validation
- go test ./google
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional request payload field gated behind a new setter and extends an existing test to assert it, with minimal impact on non-image use cases.
> 
> **Overview**
> Adds `Model.WithImageAspectRatio()` to let callers specify a Gemini image output aspect ratio and includes it in requests as `generationConfig.imageConfig.aspectRatio` when set.
> 
> Updates the Gemini 3 config test to set an aspect ratio and assert the outgoing payload contains the expected `imageConfig` block alongside existing generation config options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1452ccd499180bff4ac0180214bcbc294ac5dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->