### PR TITLE
Preserve cache hints on tool results

### DIFF
--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -263,6 +263,47 @@ func ptr(s string) *string {
 	return &s
 }
 
+func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResults(t *testing.T) {
+	messages := MessagesFromLLMWithOptions(llms.Message{
+		Role:       "tool",
+		ToolCallID: "call_123",
+		Content: content.Content{
+			&content.Text{Text: "Command executed successfully"},
+			&content.CacheHint{Duration: "short"},
+		},
+	}, chatMessageEncodingOptions{cacheControlPromptHints: true})
+
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 1)
+	assert.Equal(t, "tool", messages[0].Role)
+	assert.Equal(t, "call_123", messages[0].ToolCallID)
+	assert.Equal(t, &CacheControl{Type: "ephemeral"}, messages[0].Content[0].CacheControl)
+}
+
+func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResultsWithSecondaryContent(t *testing.T) {
+	messages := MessagesFromLLMWithOptions(llms.Message{
+		Role:       "tool",
+		ToolCallID: "call_123",
+		Content: content.Content{
+			&content.JSON{Data: json.RawMessage(`{"status":"done"}`)},
+			&content.CacheHint{Duration: "short"},
+			&content.Text{Text: "Process finished."},
+			&content.CacheHint{Duration: "short"},
+		},
+	}, chatMessageEncodingOptions{cacheControlPromptHints: true})
+
+	require.Len(t, messages, 2)
+
+	require.Len(t, messages[0].Content, 1)
+	assert.Equal(t, "tool", messages[0].Role)
+	assert.Equal(t, "call_123", messages[0].ToolCallID)
+	assert.Equal(t, &CacheControl{Type: "ephemeral"}, messages[0].Content[0].CacheControl)
+
+	require.Len(t, messages[1].Content, 1)
+	assert.Equal(t, "user", messages[1].Role)
+	assert.Equal(t, &CacheControl{Type: "ephemeral"}, messages[1].Content[0].CacheControl)
+}
+
 func TestToolCallDeltaToLLMPreservesMetadata(t *testing.T) {
 	input := toolCallDelta{
 		ID:   "call_custom",

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -280,6 +280,23 @@ func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResults(t *test
 	assert.Equal(t, &CacheControl{Type: "ephemeral"}, messages[0].Content[0].CacheControl)
 }
 
+func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResultsWithLongTTL(t *testing.T) {
+	messages := MessagesFromLLMWithOptions(llms.Message{
+		Role:       "tool",
+		ToolCallID: "call_123",
+		Content: content.Content{
+			&content.Text{Text: "Command executed successfully"},
+			&content.CacheHint{Duration: "long"},
+		},
+	}, chatMessageEncodingOptions{cacheControlPromptHints: true})
+
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 1)
+	assert.Equal(t, "tool", messages[0].Role)
+	assert.Equal(t, "call_123", messages[0].ToolCallID)
+	assert.Equal(t, &CacheControl{Type: "ephemeral", TTL: "1h"}, messages[0].Content[0].CacheControl)
+}
+
 func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResultsWithSecondaryContent(t *testing.T) {
 	messages := MessagesFromLLMWithOptions(llms.Message{
 		Role:       "tool",
@@ -288,7 +305,7 @@ func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResultsWithSeco
 			&content.JSON{Data: json.RawMessage(`{"status":"done"}`)},
 			&content.CacheHint{Duration: "short"},
 			&content.Text{Text: "Process finished."},
-			&content.CacheHint{Duration: "short"},
+			&content.CacheHint{Duration: "long"},
 		},
 	}, chatMessageEncodingOptions{cacheControlPromptHints: true})
 
@@ -301,7 +318,7 @@ func TestMessagesFromLLMWithOptions_CacheControlPromptHintsOnToolResultsWithSeco
 
 	require.Len(t, messages[1].Content, 1)
 	assert.Equal(t, "user", messages[1].Role)
-	assert.Equal(t, &CacheControl{Type: "ephemeral"}, messages[1].Content[0].CacheControl)
+	assert.Equal(t, &CacheControl{Type: "ephemeral", TTL: "1h"}, messages[1].Content[0].CacheControl)
 }
 
 func TestToolCallDeltaToLLMPreservesMetadata(t *testing.T) {
@@ -641,7 +658,7 @@ func TestBuildPayload_WithCacheControlPromptHintsAndAssistantReasoningReplay(t *
 	system := messages[0].(map[string]any)
 	systemContent := system["content"].([]any)
 	firstPart := systemContent[0].(map[string]any)
-	assert.Equal(t, map[string]any{"type": "ephemeral"}, firstPart["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral", "ttl": "1h"}, firstPart["cache_control"])
 
 	assistant := messages[1].(map[string]any)
 	reasoningDetails := assistant["reasoning_details"].([]any)

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -138,6 +138,7 @@ func MessagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions)
 		var messagesToReturn []Message
 		var primaryResultString string
 		var secondaryContent content.Content
+		var primaryCacheControl *CacheControl
 
 		if len(m.Content) > 0 {
 			firstItem := m.Content[0]
@@ -153,7 +154,18 @@ func MessagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions)
 			}
 
 			if len(m.Content) > 1 {
-				secondaryContent = m.Content[1:]
+				secondaryStart := 1
+				if opts.cacheControlPromptHints {
+					for secondaryStart < len(m.Content) {
+						_, ok := m.Content[secondaryStart].(*content.CacheHint)
+						if !ok {
+							break
+						}
+						primaryCacheControl = &CacheControl{Type: "ephemeral"}
+						secondaryStart++
+					}
+				}
+				secondaryContent = m.Content[secondaryStart:]
 			}
 		} else {
 			primaryResultString = ""
@@ -161,7 +173,7 @@ func MessagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions)
 
 		primaryMessage := Message{
 			Role:       "tool",
-			Content:    ContentList{{Type: "text", Text: &primaryResultString}},
+			Content:    ContentList{{Type: "text", Text: &primaryResultString, CacheControl: primaryCacheControl}},
 			ToolCallID: m.ToolCallID,
 		}
 		messagesToReturn = append(messagesToReturn, primaryMessage)

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -31,6 +31,7 @@ type imageURL struct {
 // CacheControl represents a cache control directive on a content part.
 type CacheControl struct {
 	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
 }
 
 // ContentPart represents a single part of a message's content array.
@@ -83,7 +84,7 @@ func ConvertContentWithOptions(c content.Content, opts chatMessageEncodingOption
 		case *content.CacheHint:
 			if opts.cacheControlPromptHints {
 				if i := len(cl) - 1; i >= 0 {
-					cl[i].CacheControl = &CacheControl{Type: "ephemeral"}
+					cl[i].CacheControl = cacheControlFromCacheHint(v)
 				}
 			}
 			continue
@@ -114,6 +115,14 @@ func (cl *ContentList) UnmarshalJSON(data []byte) error {
 	}
 	*cl = ContentList(value)
 	return nil
+}
+
+func cacheControlFromCacheHint(hint *content.CacheHint) *CacheControl {
+	cc := &CacheControl{Type: "ephemeral"}
+	if hint.Duration == "long" {
+		cc.TTL = "1h"
+	}
+	return cc
 }
 
 // Message represents a chat message in the OpenAI API format.
@@ -157,11 +166,11 @@ func MessagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions)
 				secondaryStart := 1
 				if opts.cacheControlPromptHints {
 					for secondaryStart < len(m.Content) {
-						_, ok := m.Content[secondaryStart].(*content.CacheHint)
+						cacheHint, ok := m.Content[secondaryStart].(*content.CacheHint)
 						if !ok {
 							break
 						}
-						primaryCacheControl = &CacheControl{Type: "ephemeral"}
+						primaryCacheControl = cacheControlFromCacheHint(cacheHint)
 						secondaryStart++
 					}
 				}

--- a/openrouter/openrouter_test.go
+++ b/openrouter/openrouter_test.go
@@ -63,7 +63,7 @@ func TestNew_BuildPayload_UsesOpenRouterEncoding(t *testing.T) {
 	systemMessage := messages[0].(map[string]any)
 	systemContent := systemMessage["content"].([]any)
 	firstPart := systemContent[0].(map[string]any)
-	assert.Equal(t, map[string]any{"type": "ephemeral"}, firstPart["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral", "ttl": "1h"}, firstPart["cache_control"])
 
 	assistantMessage := messages[1].(map[string]any)
 	reasoningDetails := assistantMessage["reasoning_details"].([]any)

--- a/openrouter/openrouter_test.go
+++ b/openrouter/openrouter_test.go
@@ -86,6 +86,44 @@ func TestNew_BuildPayload_UsesOpenRouterEncoding(t *testing.T) {
 	assert.Equal(t, "t3", third["id"])
 }
 
+func TestNew_BuildPayload_CachesToolResultPromptHint(t *testing.T) {
+	p := New("", "anthropic/claude-sonnet-4")
+
+	payload, err := p.BuildPayload(
+		nil,
+		[]llms.Message{{
+			Role:       "tool",
+			ToolCallID: "call_123",
+			Content: content.Content{
+				&content.Text{Text: "Tool result"},
+				&content.CacheHint{Duration: "short"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+
+	messages, ok := raw["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, messages, 1)
+
+	toolMessage := messages[0].(map[string]any)
+	assert.Equal(t, "tool", toolMessage["role"])
+	assert.Equal(t, "call_123", toolMessage["tool_call_id"])
+
+	toolContent := toolMessage["content"].([]any)
+	require.Len(t, toolContent, 1)
+	firstPart := toolContent[0].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, firstPart["cache_control"])
+}
+
 func TestNewWithReasoning_AddsReasoningPayload(t *testing.T) {
 	p := NewWithReasoning("", "anthropic/claude-sonnet-4", Reasoning{Effort: "medium"})
 


### PR DESCRIPTION
## Summary

Preserve `content.CacheHint` items that immediately follow the primary content item of an OpenAI-compatible tool result.

## Root Cause

`MessagesFromLLMWithOptions` has a special path for `role: "tool"` messages: it turns the first content item into the primary OpenAI tool-result message and converts the rest as secondary user content. When OpenRouter prompt-cache hints were appended after a tool result, the hint landed in that secondary path with no previous converted content part, so it was dropped instead of becoming `cache_control` on the tool-result content.

## Changes

- Carry leading cache hints after the primary tool-result item onto the primary `tool` message content part.
- Keep later secondary content conversion unchanged so secondary text/image parts can still receive their own cache hints.
- Add OpenAI converter tests for primary tool-result hints and secondary-content hints.
- Add an OpenRouter payload regression test showing `cache_control` serialized on cached tool results.

## Validation

- `mise exec -- go test ./openai`
- `mise exec -- go test ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies OpenAI/OpenRouter message encoding and serialized `cache_control` shape (adds optional `ttl`), which could affect downstream API payload compatibility and caching behavior.
> 
> **Overview**
> Ensures `content.CacheHint` items that immediately follow a `role:"tool"` message’s primary result are applied to the primary tool-result content part (instead of being dropped when secondary content is split into a separate `user` message).
> 
> Extends `cache_control` encoding to optionally include a `ttl` (currently `1h` for `Duration:"long"`) and adds regression tests for tool-result caching plus updated expectations for system-message cache control serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48016df41238a384f843813661441f80371a7193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->