### PR TITLE
openai: surface premature EOF in chat completions streams as ErrEmptyStream

### DIFF
--- a/llms/errors.go
+++ b/llms/errors.go
@@ -12,6 +12,15 @@ import (
 // stop_reason="max_tokens" in Anthropic).
 var ErrOutputTruncated = errors.New("output truncated: model reached max output token limit")
 
+// ErrEmptyStream is returned when a provider stream terminates without
+// producing any content. For SSE-based providers this means EOF arrived
+// before the stream's terminating marker (e.g. `data: [DONE]` on the
+// OpenAI Chat Completions API), which typically indicates the upstream
+// connection was cut prematurely (proxy timeout, middleware swallowing an
+// upstream error, empty response from the model). Without this error,
+// callers would observe a successful completion with zero tokens.
+var ErrEmptyStream = errors.New("stream ended without producing content")
+
 // HTTPError represents an HTTP error response from an LLM provider.
 type HTTPError struct {
 	StatusCode int               // HTTP status code (e.g., 429, 503, 500)

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -660,6 +660,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 	reader := bufio.NewReader(s.stream)
 	var activeToolCallIndex = -1 // Track the index of the tool call being processed
 	messageStartYielded := false
+	doneSeen := false // Whether the SSE terminator `data: [DONE]` was observed
 
 	return func(rawYield func(llms.StreamStatus) bool) {
 		stopped := false
@@ -698,6 +699,15 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				if err != nil {
 					if err == io.EOF {
 						if lineBuilder.Len() == 0 {
+							// Per the Chat Completions streaming spec, providers
+							// terminate streams with `data: [DONE]`. EOF without
+							// [DONE] means the connection closed abruptly (proxy
+							// timeout, middleware swallowing an upstream error,
+							// empty response from the model). Without this, the
+							// caller would observe a successful empty completion.
+							if !doneSeen && s.err == nil {
+								s.err = llms.ErrEmptyStream
+							}
 							return
 						}
 						break
@@ -723,6 +733,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				continue
 			}
 			if line == "[DONE]" {
+				doneSeen = true
 				// Stream ended. If we were still thinking, emit ThinkingDone.
 				if s.lastThought != nil {
 					s.lastThought = nil

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -703,9 +703,17 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 							// terminate streams with `data: [DONE]`. EOF without
 							// [DONE] means the connection closed abruptly (proxy
 							// timeout, middleware swallowing an upstream error,
-							// empty response from the model). Without this, the
-							// caller would observe a successful empty completion.
-							if !doneSeen && s.err == nil {
+							// empty response from the model).
+							//
+							// Only error when nothing was yielded. If at least one
+							// chunk was processed, downstream may have already done
+							// real work (executed a tool call, captured partial
+							// content, etc.); turning that into an error would make
+							// the caller retry and re-run those side effects. The
+							// API-layer "zero tokens" guard catches the empty-but-
+							// truncated case. We're enforcing transport here, not
+							// outcome.
+							if !doneSeen && !messageStartYielded && s.err == nil {
 								s.err = llms.ErrEmptyStream
 							}
 							return

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -660,7 +660,8 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 	reader := bufio.NewReader(s.stream)
 	var activeToolCallIndex = -1 // Track the index of the tool call being processed
 	messageStartYielded := false
-	doneSeen := false // Whether the SSE terminator `data: [DONE]` was observed
+	doneSeen := false        // Whether the SSE terminator `data: [DONE]` was observed
+	toolReadyYielded := false // Whether StreamStatusToolCallReady was yielded; gates ErrEmptyStream so a tool's side effect isn't redone via retry
 
 	return func(rawYield func(llms.StreamStatus) bool) {
 		stopped := false
@@ -705,15 +706,13 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 							// timeout, middleware swallowing an upstream error,
 							// empty response from the model).
 							//
-							// Only error when nothing was yielded. If at least one
-							// chunk was processed, downstream may have already done
-							// real work (executed a tool call, captured partial
-							// content, etc.); turning that into an error would make
-							// the caller retry and re-run those side effects. The
-							// API-layer "zero tokens" guard catches the empty-but-
-							// truncated case. We're enforcing transport here, not
-							// outcome.
-							if !doneSeen && !messageStartYielded && s.err == nil {
+							// Suppress this error specifically when a tool call was
+							// already yielded as ready: the caller will have run the
+							// tool by the time we get here, and turning a missing
+							// terminator into an error would force a retry that
+							// re-runs the tool side effect. Truncated text-only
+							// streams still error, since retrying those is safe.
+							if !doneSeen && !toolReadyYielded && s.err == nil {
 								s.err = llms.ErrEmptyStream
 							}
 							return
@@ -751,6 +750,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				}
 				// If a tool call was active, mark it as ready.
 				if activeToolCallIndex != -1 {
+					toolReadyYielded = true
 					if !yield(llms.StreamStatusToolCallReady) {
 						return
 					}
@@ -835,6 +835,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 						}
 						// If a previous tool call was active, mark it as ready now.
 						if activeToolCallIndex != -1 {
+							toolReadyYielded = true
 							if !yield(llms.StreamStatusToolCallReady) {
 								return // Abort if yield fails
 							}
@@ -884,6 +885,7 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				switch *chunk.Choices[0].FinishReason {
 				case "tool_calls":
 					if activeToolCallIndex != -1 {
+						toolReadyYielded = true
 						if !yield(llms.StreamStatusToolCallReady) {
 							return // Abort if yield fails
 						}

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -750,3 +750,69 @@ func TestDoRequest_OpenRouterErrorMetadata(t *testing.T) {
 func intPtr(v int) *int {
 	return &v
 }
+
+// TestChatCompletionsStream_EOFWithoutDone covers the case where the upstream
+// closes the SSE connection cleanly but never sends the `data: [DONE]`
+// terminator. This is what we observed on `openrouter/claude-4.6-opus-*`
+// and `gpt-5.*`: the stream returns 200, the connection closes, and our
+// iterator used to exit silently — yielding `success=true` with zero
+// tokens and an empty assistant message. The fix surfaces this as
+// `llms.ErrEmptyStream` so callers can retry or fail loud.
+func TestChatCompletionsStream_EOFWithoutDone(t *testing.T) {
+	t.Run("no chunks at all", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		stream := New("", "test-model").WithEndpoint(ts.URL, "Test").DoRequest(context.Background(), map[string]any{
+			"model":    "test-model",
+			"messages": []Message{},
+			"stream":   true,
+		})
+		require.NoError(t, stream.Err())
+		for range stream.Iter() {
+		}
+		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
+	})
+
+	t.Run("chunks but no DONE", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// One valid chunk, then connection close without [DONE].
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-x\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}\n\n"))
+		}))
+		defer ts.Close()
+
+		stream := New("", "test-model").WithEndpoint(ts.URL, "Test").DoRequest(context.Background(), map[string]any{
+			"model":    "test-model",
+			"messages": []Message{},
+			"stream":   true,
+		})
+		require.NoError(t, stream.Err())
+		for range stream.Iter() {
+		}
+		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
+	})
+
+	t.Run("DONE marker keeps clean exit", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{}}]}\n\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		}))
+		defer ts.Close()
+
+		stream := New("", "test-model").WithEndpoint(ts.URL, "Test").DoRequest(context.Background(), map[string]any{
+			"model":    "test-model",
+			"messages": []Message{},
+			"stream":   true,
+		})
+		require.NoError(t, stream.Err())
+		for range stream.Iter() {
+		}
+		require.NoError(t, stream.Err())
+	})
+}

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -777,11 +777,14 @@ func TestChatCompletionsStream_EOFWithoutDone(t *testing.T) {
 		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
 	})
 
-	t.Run("chunks but no DONE", func(t *testing.T) {
+	t.Run("chunks but no DONE does not error", func(t *testing.T) {
+		// Once any chunk has been processed, downstream may already have
+		// done real work (text captured, tool call executed). Erroring
+		// here would force the caller to retry and re-run side effects.
+		// Outcome enforcement (zero tokens, etc.) belongs above the SDK.
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
-			// One valid chunk, then connection close without [DONE].
 			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-x\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}\n\n"))
 		}))
 		defer ts.Close()
@@ -794,7 +797,35 @@ func TestChatCompletionsStream_EOFWithoutDone(t *testing.T) {
 		require.NoError(t, stream.Err())
 		for range stream.Iter() {
 		}
-		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
+		require.NoError(t, stream.Err())
+	})
+
+	t.Run("tool call followed by EOF without DONE preserves work", func(t *testing.T) {
+		// Bugbot scenario: stream completes a tool call (which the caller
+		// will have already executed) and then the connection drops before
+		// [DONE]. Erroring here would make the caller retry and re-run
+		// the tool — the side effect must not be undone.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-x\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"foo\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n"))
+		}))
+		defer ts.Close()
+
+		stream := New("", "test-model").WithEndpoint(ts.URL, "Test").DoRequest(context.Background(), map[string]any{
+			"model":    "test-model",
+			"messages": []Message{},
+			"stream":   true,
+		})
+		require.NoError(t, stream.Err())
+		var sawToolCallReady bool
+		for status := range stream.Iter() {
+			if status == llms.StreamStatusToolCallReady {
+				sawToolCallReady = true
+			}
+		}
+		require.NoError(t, stream.Err())
+		assert.True(t, sawToolCallReady, "tool call should have been yielded as ready")
 	})
 
 	t.Run("DONE marker keeps clean exit", func(t *testing.T) {

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -777,11 +777,11 @@ func TestChatCompletionsStream_EOFWithoutDone(t *testing.T) {
 		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
 	})
 
-	t.Run("chunks but no DONE does not error", func(t *testing.T) {
-		// Once any chunk has been processed, downstream may already have
-		// done real work (text captured, tool call executed). Erroring
-		// here would force the caller to retry and re-run side effects.
-		// Outcome enforcement (zero tokens, etc.) belongs above the SDK.
+	t.Run("text content but no DONE", func(t *testing.T) {
+		// Truncated text-only stream: no tool was executed, so retrying
+		// is safe. We surface the missing terminator as ErrEmptyStream
+		// so the caller can either retry or fail loud — not silently
+		// accept a half-stream as success.
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
@@ -797,14 +797,14 @@ func TestChatCompletionsStream_EOFWithoutDone(t *testing.T) {
 		require.NoError(t, stream.Err())
 		for range stream.Iter() {
 		}
-		require.NoError(t, stream.Err())
+		require.ErrorIs(t, stream.Err(), llms.ErrEmptyStream)
 	})
 
 	t.Run("tool call followed by EOF without DONE preserves work", func(t *testing.T) {
-		// Bugbot scenario: stream completes a tool call (which the caller
-		// will have already executed) and then the connection drops before
-		// [DONE]. Erroring here would make the caller retry and re-run
-		// the tool — the side effect must not be undone.
+		// Stream completes a tool call (which the caller will have
+		// already executed) and then the connection drops before [DONE].
+		// Erroring here would make the caller retry and re-run the tool;
+		// the side effect must not be undone.
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- The Chat Completions SSE iterator used to return silently on EOF when no `data: [DONE]` terminator had been observed. Callers got a successful empty completion (zero tokens, no error) instead of a real failure they could retry.
- This change tracks whether `[DONE]` was observed and surfaces premature EOF as a new sentinel `llms.ErrEmptyStream`. The check is protocol-level (SSE termination), not content-based, so streams that legitimately end with `[DONE]` and zero content remain non-errors — outcome enforcement belongs above the SDK.

## Motivation

In production we observed a class of LLM calls that reported `llm.success=true` with `input_tokens=0, output_tokens=0` and 3-6 second latencies, all routed through this Chat Completions parser (`openrouter/claude-4.6-opus-*`, `openrouter/claude-4.5-haiku`, `gpt-5.*`). 71 occurrences in 7 days. The upstream had closed the SSE connection without ever sending `[DONE]`; the iterator exited the EOF branch with `s.err == nil` and the consumer treated the result as a real empty completion. In one debugged incident, an entire multi-turn agent workflow ran three back-to-back empty completions and finalized as "successful" with no edits made.

## Test plan

- [x] New regression test `TestChatCompletionsStream_EOFWithoutDone` with three sub-cases:
  - Server returns 200 with no body at all → `ErrEmptyStream`
  - Server returns 200 with one valid chunk but no `[DONE]` → `ErrEmptyStream`
  - Server returns 200 with chunk + `[DONE]` → no error (existing behavior preserved)
- [x] `go test ./openai/... ./llms/...` green
- [x] `go test ./...` across all packages green (anthropic, content, google, openrouter, tools)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenAI Chat Completions streaming to treat EOF-before-`[DONE]` as an error, which can alter downstream success/retry behavior. Adds a guard to avoid turning post-tool-call EOF into an error to prevent re-running tool side effects on retry.
> 
> **Overview**
> Prevents silent “successful” empty completions by introducing a new sentinel error `llms.ErrEmptyStream` and returning it when a Chat Completions SSE stream hits EOF without the `data: [DONE]` terminator.
> 
> Updates the stream iterator to track whether `[DONE]` was observed and to **suppress** `ErrEmptyStream` once a tool call has been yielded as ready, avoiding retries that could re-run tool side effects. Adds regression tests covering EOF-without-DONE for empty streams, truncated text-only streams, and tool-call streams, plus a control case with a proper `[DONE]` marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3ca02b2720aa9e2d5b612e60891d85f726a20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->