### PR TITLE
Add RawTool for provider-specific Responses API server-side tools

### DIFF
--- a/openai/responses_raw_tool_test.go
+++ b/openai/responses_raw_tool_test.go
@@ -1,0 +1,93 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+)
+
+// TestResponsesRawToolSerialized verifies a RawTool is emitted verbatim into the
+// request's "tools" array, so callers can express provider-specific server-side
+// tools (e.g. xAI's web_search / x_search) that have no dedicated type here.
+func TestResponsesRawToolSerialized(t *testing.T) {
+	var capturedBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer ts.Close()
+
+	stream := NewResponsesAPI("key", "grok-4.3").
+		WithEndpoint(ts.URL, "xAI").
+		WithTool(RawTool{Body: map[string]any{"type": "web_search"}}).
+		WithTool(RawTool{Body: map[string]any{"type": "x_search", "allowed_x_handles": []string{"paulg"}}}).
+		Generate(context.Background(), content.FromText("system"), []llms.Message{{
+			Role:    "user",
+			Content: content.FromText("hi"),
+		}}, nil, nil)
+
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+
+	var payload struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(capturedBody, &payload))
+	require.Len(t, payload.Tools, 2)
+	assert.Equal(t, "web_search", payload.Tools[0]["type"])
+	assert.Equal(t, "x_search", payload.Tools[1]["type"])
+	assert.Equal(t, []any{"paulg"}, payload.Tools[1]["allowed_x_handles"])
+}
+
+// TestXAIResponsesLiveSearch is an opt-in end-to-end check against the live xAI
+// Responses API: a RawTool expresses xAI's web_search + x_search Agent Tools and
+// the streamed answer parses back. Skipped unless XAI_API_KEY is set, so normal
+// CI never hits the network.
+func TestXAIResponsesLiveSearch(t *testing.T) {
+	apiKey := os.Getenv("XAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("XAI_API_KEY not set; skipping live xAI Responses test")
+	}
+
+	provider := NewResponsesAPI(apiKey, "grok-4.3").
+		WithEndpoint("https://api.x.ai/v1/responses", "xAI").
+		WithMaxOutputTokens(2048).
+		WithTool(RawTool{Body: map[string]any{"type": "web_search"}}).
+		WithTool(RawTool{Body: map[string]any{"type": "x_search", "allowed_x_handles": []string{"paulg"}}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	stream := provider.Generate(ctx, content.FromText("You research people from public web and X signals."), []llms.Message{{
+		Role:    "user",
+		Content: content.FromText("Who is @paulg on X? Answer in one sentence and include the source URL you used."),
+	}}, nil, nil)
+
+	// Text() returns the latest delta on each StreamStatusText, so accumulate.
+	var sb strings.Builder
+	for status := range stream.Iter() {
+		if status == llms.StreamStatusText {
+			sb.WriteString(stream.Text())
+		}
+	}
+	require.NoError(t, stream.Err())
+
+	got := strings.TrimSpace(sb.String())
+	t.Logf("xAI live response: %s", got)
+	require.NotEmpty(t, got, "expected a non-empty answer from xAI Responses + Agent Tools")
+	assert.Contains(t, got, "Graham", "expected the answer to identify Paul Graham")
+}

--- a/openai/responses_types.go
+++ b/openai/responses_types.go
@@ -626,6 +626,21 @@ type LocalShellTool struct {
 
 func (LocalShellTool) responseTool() {}
 
+// RawTool is a ResponseTool whose JSON body is provided verbatim by the caller.
+// It exists so callers can express provider-specific server-side tools that
+// go-llms does not model with a dedicated type — for example xAI's "web_search"
+// and "x_search" Agent Tools. Body is marshaled as-is into the request's "tools"
+// array, so it must include the tool's "type" discriminator.
+type RawTool struct {
+	Body any
+}
+
+func (RawTool) responseTool() {}
+
+func (t RawTool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Body)
+}
+
 // Response format types
 
 // TextResponseFormat represents the text response format configuration.


### PR DESCRIPTION
## What

`ResponseTool` is a sealed interface (unexported `responseTool()`), so callers in other packages can't add tools this library doesn't model with a dedicated type. `RawTool` closes that gap: it's a `ResponseTool` whose JSON `Body` is marshaled **verbatim** into the request's `tools` array.

## Why

We need xAI's **Agent Tools** — `web_search` and `x_search` — on the Responses API (`api.x.ai/v1/responses`). They have no dedicated tool type here: xAI's `web_search` differs from OpenAI's `web_search_preview`, and `x_search` (with `allowed_x_handles`) is xAI-only. `RawTool{Body: map[string]any{"type":"x_search","allowed_x_handles":[...]}}` expresses them without baking provider specifics into go-llms.

## Tests

- `TestResponsesRawToolSerialized` — mock server; asserts the raw tool JSON lands verbatim in the `tools` array (CI-runnable, no network).
- `TestXAIResponsesLiveSearch` — opt-in end-to-end against live xAI (skipped unless `XAI_API_KEY` is set). Verified it runs web + X search server-side and streams a cited answer back through the existing `ResponsesStream` parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API surface and tests only; no changes to existing tool serialization or request building beyond the new type.
> 
> **Overview**
> Adds **`RawTool`** as a new `ResponseTool` so callers can pass arbitrary provider-specific server-side tool JSON (via `Body`) into the Responses API `tools` array without a dedicated struct—`MarshalJSON` emits `Body` verbatim, including the required `type` field.
> 
> This is aimed at tools like xAI’s `web_search` and `x_search` (with `allowed_x_handles`) that differ from existing modeled types such as OpenAI’s `web_search_preview`.
> 
> **Tests:** `TestResponsesRawToolSerialized` uses a mock HTTP server to assert two `RawTool` entries appear unchanged in the request body; `TestXAIResponsesLiveSearch` is an opt-in live xAI check skipped when `XAI_API_KEY` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 560700c69f5c91017844cd6638211c327e6f9389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->