### PR TITLE
Don't execute xAI's server-side x_search sub-tool calls

### DIFF
--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -147,11 +147,6 @@ func (p *responsesEventProcessor) processEvent(
 					}
 				}
 			case "custom_tool_call":
-				if p.activeToolCall != nil {
-					if !yield(llms.StreamStatusToolCallReady) {
-						return true
-					}
-				}
 				var ctc struct {
 					Type   string `json:"type"`
 					ID     string `json:"id"`
@@ -162,6 +157,20 @@ func (p *responsesEventProcessor) processEvent(
 				if err := json.Unmarshal(event.Item, &ctc); err != nil {
 					ctc.ID = item.ID
 					ctc.Name = "custom"
+				}
+				// xAI executes its Agent Tool sub-tools server-side (e.g. x_search's
+				// x_user_search / x_keyword_search) and streams them as custom_tool_calls
+				// before continuing to the final message. These are hosted, not client tools,
+				// so they must not be surfaced for execution — the turn loop would otherwise
+				// fail with "tool not found". Ignore them, mirroring how built-in items like
+				// web_search_call are ignored.
+				if isHostedResponsesToolCall(ctc.CallID) {
+					break
+				}
+				if p.activeToolCall != nil {
+					if !yield(llms.StreamStatusToolCallReady) {
+						return true
+					}
 				}
 				metadata := map[string]string{
 					"openai:item_id":   ctc.ID,
@@ -420,4 +429,13 @@ func (p *responsesEventProcessor) processEvent(
 	}
 
 	return false
+}
+
+// isHostedResponsesToolCall reports whether a Responses API custom_tool_call is a
+// provider-executed (hosted) Agent Tool call rather than a client tool the caller must
+// run. xAI streams its server-side x_search sub-tools (x_user_search, x_keyword_search,
+// x_semantic_search, x_thread_fetch) as custom_tool_calls with a call_id prefixed "xs_";
+// the client must not try to execute them.
+func isHostedResponsesToolCall(callID string) bool {
+	return strings.HasPrefix(callID, "xs_")
 }

--- a/openai/responses_xai_hosted_test.go
+++ b/openai/responses_xai_hosted_test.go
@@ -1,0 +1,69 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/llms"
+)
+
+// xaiHostedXSearchSSE mirrors a real xAI Responses stream where the x_search Agent Tool runs
+// its server-side x_user_search sub-tool (a custom_tool_call with call_id prefixed "xs_") and
+// then completes with a final message. Before the fix the turn loop tried to execute
+// x_user_search against the (empty) client toolbox and failed with "tool not found".
+const xaiHostedXSearchSSE = `data: {"type":"response.created","response":{"id":"resp_1"}}
+
+data: {"type":"response.output_item.added","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","input":"","status":"in_progress"},"output_index":1}
+
+data: {"type":"response.custom_tool_call_input.delta","item_id":"ctc_1","delta":"{\"query\":\"paulg\"}"}
+
+data: {"type":"response.custom_tool_call_input.done","item_id":"ctc_1"}
+
+data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","status":"completed"}}
+
+data: {"type":"response.output_item.added","item":{"type":"message","id":"msg_1","status":"in_progress"}}
+
+data: {"type":"response.output_text.delta","item_id":"msg_1","content_index":0,"delta":"Paul Graham co-founded Y Combinator."}
+
+data: {"type":"response.output_item.done","item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Paul Graham co-founded Y Combinator."}]}}
+
+data: {"type":"response.completed"}
+
+`
+
+// The parser must not surface xAI's hosted x_search sub-tool calls as client tool calls.
+func TestResponsesXAIHostedToolCallNotSurfaced(t *testing.T) {
+	stream := &ResponsesStream{ctx: context.Background(), model: "grok-4.3", stream: strings.NewReader(xaiHostedXSearchSSE)}
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+	assert.Empty(t, stream.Message().ToolCalls, "hosted x_search sub-tool calls must not surface as client tool calls")
+}
+
+// The full turn loop must complete with the final message instead of failing "tool not found".
+func TestResponsesXAIHostedToolCallTurnLoop(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, xaiHostedXSearchSSE)
+	}))
+	defer ts.Close()
+
+	llm := llms.New(NewResponsesAPI("k", "grok-4.3").WithEndpoint(ts.URL, "xAI")).WithMaxTurns(1)
+
+	var text strings.Builder
+	for update := range llm.ChatWithContext(context.Background(), "Who is @paulg?") {
+		if tu, ok := update.(llms.TextUpdate); ok {
+			text.WriteString(tu.Text)
+		}
+	}
+
+	require.NoError(t, llm.Err())
+	assert.Contains(t, text.String(), "Y Combinator")
+}


### PR DESCRIPTION
## Problem

xAI's `x_search` Agent Tool runs its sub-tools (`x_user_search`, `x_keyword_search`, ...) **server-side** and streams them back as `custom_tool_call` items (with a `call_id` prefixed `xs_`), then continues to a final message. The Responses parser surfaced these as **client** tool calls, so the turn loop did `toolbox.Get("x_user_search")` -> nil and failed with:

```
tool "x_user_search" not found
```

The direct xAI call works; only the go-llms turn loop broke, because built-in items like `web_search_call` were already ignored but `x_search`'s hosted sub-tools were not.

## Fix

In `openai/responses_events.go`, skip hosted `custom_tool_call`s (identified by the `xs_`-prefixed `call_id`) instead of adding them to `message.ToolCalls` / emitting `StreamStatusToolCallBegin`. Genuine client custom tools are unaffected.

## Tests

- `TestResponsesXAIHostedToolCallNotSurfaced` — parser level: hosted sub-tool calls don't surface as client tool calls.
- `TestResponsesXAIHostedToolCallTurnLoop` — drives the full `llms.New(provider)` turn loop with a captured `x_search` SSE; reproduces the `tool "x_user_search" not found` failure without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parser change keyed on `xs_` call_id prefix; only affects surfacing of hosted xAI sub-tools, with targeted tests.
> 
> **Overview**
> Fixes the Responses API stream parser so **xAI server-side `x_search` sub-tools** (streamed as `custom_tool_call` items with `call_id` prefixed `xs_`) are **not** exposed as client tool calls. Without this, the turn loop tried to run tools like `x_user_search` locally and failed with **tool not found** even though xAI had already executed them.
> 
> The `custom_tool_call` handler now calls **`isHostedResponsesToolCall`** and skips those items, similar to ignoring provider-built-in items such as `web_search_call`. Real client custom tools (non-`xs_` call IDs) are unchanged.
> 
> Adds **`responses_xai_hosted_test.go`**: one test asserts hosted calls never appear on `Message().ToolCalls`, and one drives the full chat turn loop against captured SSE to ensure the assistant text completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c546fa5114db5116ad9dc56fd73aabe13287baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->