### PR TITLE
Surface xAI provider-run searches as stream events

### DIFF
--- a/llms/llm.go
+++ b/llms/llm.go
@@ -336,6 +336,14 @@ func (l *LLM) turn(ctx context.Context, updateChan chan<- Update) (bool, error) 
 		case StreamStatusThinkingDone:
 			updateChan <- ThinkingDoneUpdate{}
 
+		case StreamStatusSearch:
+			// Provider-run search (e.g. xAI web_search / x_search) is informational: it runs
+			// server-side, so there is nothing to execute. Only providers that surface it
+			// implement Search(), so this is an optional capability rather than an interface method.
+			if searcher, ok := stream.(interface{ Search() SearchActivity }); ok {
+				updateChan <- SearchUpdate{searcher.Search()}
+			}
+
 		case StreamStatusToolCallBegin:
 			toolCall := stream.ToolCall()
 			if toolCall.ID == "" {

--- a/llms/streamstatus.go
+++ b/llms/streamstatus.go
@@ -23,4 +23,7 @@ const (
 	StreamStatusThinkingDone
 	// StreamStatusMessageStart means the stream surfaced the server-assigned message ID.
 	StreamStatusMessageStart
+	// StreamStatusSearch means the stream surfaced a provider-run search the model performed
+	// (e.g. xAI's web_search / x_search Agent Tools), with its query and any result count.
+	StreamStatusSearch
 )

--- a/llms/update.go
+++ b/llms/update.go
@@ -20,6 +20,7 @@ const (
 	UpdateTypeThinking     UpdateType = "thinking"
 	UpdateTypeThinkingDone UpdateType = "thinking_done"
 	UpdateTypeMessageStart UpdateType = "message_start"
+	UpdateTypeSearch       UpdateType = "search"
 )
 
 type Update interface {
@@ -116,4 +117,32 @@ type MessageStartUpdate struct {
 
 func (u MessageStartUpdate) Type() UpdateType {
 	return UpdateTypeMessageStart
+}
+
+// SearchSource is one result a provider-run search drew on, when the provider reports them.
+type SearchSource struct {
+	Title string
+	URL   string
+}
+
+// SearchActivity describes a single provider-run search the model performed (e.g. xAI's
+// web_search / x_search Agent Tools). It is informational: these searches run server-side, so
+// the caller never executes anything, but surfacing the query lets a UI show what was looked up.
+type SearchActivity struct {
+	// Source is the surface searched, e.g. "web" or "x".
+	Source string
+	// Query is the search query the model issued.
+	Query string
+	// ResultCount is how many results the search returned, or 0 when the provider omits it.
+	ResultCount int
+	// Sources are the result sources when the provider includes them, otherwise empty.
+	Sources []SearchSource
+}
+
+type SearchUpdate struct {
+	SearchActivity
+}
+
+func (u SearchUpdate) Type() UpdateType {
+	return UpdateTypeSearch
 }

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -286,6 +286,12 @@ func (s *ResponsesStream) Thought() content.Thought {
 	return content.Thought{}
 }
 
+// Search returns the most recently completed provider-run search (web_search / x_search),
+// read by the turn loop when it sees StreamStatusSearch.
+func (s *ResponsesStream) Search() llms.SearchActivity {
+	return s.lastSearch
+}
+
 func (s *ResponsesStream) Usage() llms.Usage {
 	if s.usage == nil {
 		return llms.Usage{}

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -147,11 +147,6 @@ func (p *responsesEventProcessor) processEvent(
 					}
 				}
 			case "custom_tool_call":
-				if p.activeToolCall != nil {
-					if !yield(llms.StreamStatusToolCallReady) {
-						return true
-					}
-				}
 				var ctc struct {
 					Type   string `json:"type"`
 					ID     string `json:"id"`
@@ -162,6 +157,20 @@ func (p *responsesEventProcessor) processEvent(
 				if err := json.Unmarshal(event.Item, &ctc); err != nil {
 					ctc.ID = item.ID
 					ctc.Name = "custom"
+				}
+				// xAI executes its Agent Tool sub-tools server-side (e.g. x_search's
+				// x_user_search / x_keyword_search) and streams them as custom_tool_calls
+				// before continuing to the final message. These are hosted, not client tools,
+				// so they must not be surfaced for execution — the turn loop would otherwise
+				// fail with "tool not found". Ignore them, mirroring how built-in items like
+				// web_search_call are ignored.
+				if isHostedResponsesToolCall(ctc.CallID) {
+					break
+				}
+				if p.activeToolCall != nil {
+					if !yield(llms.StreamStatusToolCallReady) {
+						return true
+					}
 				}
 				metadata := map[string]string{
 					"openai:item_id":   ctc.ID,
@@ -420,4 +429,13 @@ func (p *responsesEventProcessor) processEvent(
 	}
 
 	return false
+}
+
+// isHostedResponsesToolCall reports whether a Responses API custom_tool_call is a
+// provider-executed (hosted) Agent Tool call rather than a client tool the caller must
+// run. xAI streams its server-side x_search sub-tools (x_user_search, x_keyword_search,
+// x_semantic_search, x_thread_fetch) as custom_tool_calls with a call_id prefixed "xs_";
+// the client must not try to execute them.
+func isHostedResponsesToolCall(callID string) bool {
+	return strings.HasPrefix(callID, "xs_")
 }

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -278,6 +278,16 @@ func (p *responsesEventProcessor) processEvent(
 		}
 
 	case "response.custom_tool_call_input.done":
+		var done struct {
+			ItemID string `json:"item_id"`
+		}
+		_ = json.Unmarshal(rawJSON, &done)
+		// A hosted x_search sub-call's done belongs to that hosted item, not a client tool, so
+		// it must not finalize an unrelated client tool whose deltas are still streaming. The
+		// hosted query surfaces later on output_item.done.
+		if p.hostedSearch[done.ItemID] != nil {
+			break
+		}
 		if p.activeToolCall != nil {
 			if !yield(llms.StreamStatusToolCallReady) {
 				return true

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -178,6 +178,15 @@ func (p *responsesEventProcessor) processEvent(
 				// fail with "tool not found". Instead, track them so the search query can be
 				// surfaced as StreamStatusSearch once the call completes.
 				if isHostedResponsesToolCall(ctc.CallID) {
+					// A new output item finalizes any still-active client tool call, the
+					// same invariant the non-hosted paths keep below; otherwise a client
+					// tool could stay open across the hosted call until response.completed.
+					if p.activeToolCall != nil {
+						if !yield(llms.StreamStatusToolCallReady) {
+							return true
+						}
+						p.activeToolCall = nil
+					}
 					if p.hostedSearch == nil {
 						p.hostedSearch = map[string]*hostedSearchCall{}
 					}
@@ -256,14 +265,15 @@ func (p *responsesEventProcessor) processEvent(
 			ItemID string `json:"item_id"`
 		}
 		if err := json.Unmarshal(rawJSON, &delta); err == nil {
-			if p.activeToolCall != nil {
+			// Route by item id: a tracked hosted x_search sub-call owns its deltas even if a
+			// client tool is still active, so its query is never merged into the wrong tool.
+			if tracked := p.hostedSearch[delta.ItemID]; tracked != nil {
+				tracked.input.WriteString(delta.Delta)
+			} else if p.activeToolCall != nil {
 				p.activeToolCall.Arguments = append(p.activeToolCall.Arguments, []byte(delta.Delta)...)
 				if !yield(llms.StreamStatusToolCallDelta) {
 					return true
 				}
-			} else if tracked := p.hostedSearch[delta.ItemID]; tracked != nil {
-				// Hosted x_search sub-call: accumulate its query, surfaced on completion.
-				tracked.input.WriteString(delta.Delta)
 			}
 		}
 

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -23,6 +23,19 @@ type responsesEventProcessor struct {
 	debugger          llms.Debugger
 	err               error
 	processedImageIDs map[string]bool
+	// lastSearch holds the most recently completed provider-run search (web_search / x_search),
+	// surfaced via StreamStatusSearch so a UI can show what the model looked up.
+	lastSearch llms.SearchActivity
+	// hostedSearch tracks in-flight provider-executed search sub-calls (xAI's x_search runs
+	// x_user_search / x_keyword_search server-side) by their output item id, so the streamed
+	// query can be accumulated and surfaced once the call completes.
+	hostedSearch map[string]*hostedSearchCall
+}
+
+// hostedSearchCall accumulates a provider-executed search sub-call until it completes.
+type hostedSearchCall struct {
+	source string
+	input  strings.Builder
 }
 
 // processImageItem processes a single image_generation_call item and yields
@@ -162,9 +175,15 @@ func (p *responsesEventProcessor) processEvent(
 				// x_user_search / x_keyword_search) and streams them as custom_tool_calls
 				// before continuing to the final message. These are hosted, not client tools,
 				// so they must not be surfaced for execution — the turn loop would otherwise
-				// fail with "tool not found". Ignore them, mirroring how built-in items like
-				// web_search_call are ignored.
+				// fail with "tool not found". Instead, track them so the search query can be
+				// surfaced as StreamStatusSearch once the call completes.
 				if isHostedResponsesToolCall(ctc.CallID) {
+					if p.hostedSearch == nil {
+						p.hostedSearch = map[string]*hostedSearchCall{}
+					}
+					tracked := &hostedSearchCall{source: "x"}
+					tracked.input.WriteString(ctc.Input)
+					p.hostedSearch[ctc.ID] = tracked
 					break
 				}
 				if p.activeToolCall != nil {
@@ -232,15 +251,19 @@ func (p *responsesEventProcessor) processEvent(
 		}
 
 	case "response.custom_tool_call_input.delta":
-		if p.activeToolCall != nil {
-			var delta struct {
-				Delta string `json:"delta"`
-			}
-			if err := json.Unmarshal(rawJSON, &delta); err == nil {
+		var delta struct {
+			Delta  string `json:"delta"`
+			ItemID string `json:"item_id"`
+		}
+		if err := json.Unmarshal(rawJSON, &delta); err == nil {
+			if p.activeToolCall != nil {
 				p.activeToolCall.Arguments = append(p.activeToolCall.Arguments, []byte(delta.Delta)...)
 				if !yield(llms.StreamStatusToolCallDelta) {
 					return true
 				}
+			} else if tracked := p.hostedSearch[delta.ItemID]; tracked != nil {
+				// Hosted x_search sub-call: accumulate its query, surfaced on completion.
+				tracked.input.WriteString(delta.Delta)
 			}
 		}
 
@@ -305,9 +328,36 @@ func (p *responsesEventProcessor) processEvent(
 		var itemHdr struct {
 			Type   string `json:"type"`
 			Status string `json:"status"`
+			ID     string `json:"id"`
 		}
 		if err := json.Unmarshal(event.Item, &itemHdr); err == nil {
 			switch itemHdr.Type {
+			case "web_search_call":
+				// A completed provider-run web search. The query lives in the search action;
+				// open_page / find actions carry a URL instead, so they yield no query.
+				var wsc struct {
+					Action struct {
+						Type  string `json:"type"`
+						Query string `json:"query"`
+					} `json:"action"`
+				}
+				if err := json.Unmarshal(event.Item, &wsc); err == nil && wsc.Action.Query != "" {
+					p.lastSearch = llms.SearchActivity{Source: "web", Query: wsc.Action.Query}
+					if !yield(llms.StreamStatusSearch) {
+						return true
+					}
+				}
+			case "custom_tool_call":
+				// A completed hosted x_search sub-call: surface its accumulated query.
+				if tracked := p.hostedSearch[itemHdr.ID]; tracked != nil {
+					delete(p.hostedSearch, itemHdr.ID)
+					if query := extractSearchQuery(tracked.input.String()); query != "" {
+						p.lastSearch = llms.SearchActivity{Source: tracked.source, Query: query}
+						if !yield(llms.StreamStatusSearch) {
+							return true
+						}
+					}
+				}
 			case "image_generation_call":
 				if p.processImageItem(event.Item, yield) {
 					return true
@@ -438,4 +488,28 @@ func (p *responsesEventProcessor) processEvent(
 // the client must not try to execute them.
 func isHostedResponsesToolCall(callID string) bool {
 	return strings.HasPrefix(callID, "xs_")
+}
+
+// extractSearchQuery pulls the human-readable query out of a hosted search sub-call's JSON input
+// (e.g. x_user_search's {"query":"..."}). It falls back across the field names xAI's x_search
+// sub-tools use, and returns "" when the input is empty, not JSON, or carries no recognizable query.
+func extractSearchQuery(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	var fields struct {
+		Query   string `json:"query"`
+		Keyword string `json:"keyword"`
+		Handle  string `json:"handle"`
+	}
+	if err := json.Unmarshal([]byte(input), &fields); err != nil {
+		return ""
+	}
+	for _, candidate := range []string{fields.Query, fields.Keyword, fields.Handle} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -333,16 +333,32 @@ func (p *responsesEventProcessor) processEvent(
 		if err := json.Unmarshal(event.Item, &itemHdr); err == nil {
 			switch itemHdr.Type {
 			case "web_search_call":
-				// A completed provider-run web search. The query lives in the search action;
-				// open_page / find actions carry a URL instead, so they yield no query.
+				// A completed provider-run web search. The query lives in the search action,
+				// which also carries the result sources; open_page / find actions carry a URL
+				// instead, so they yield no query.
 				var wsc struct {
 					Action struct {
-						Type  string `json:"type"`
-						Query string `json:"query"`
+						Type    string `json:"type"`
+						Query   string `json:"query"`
+						Sources []struct {
+							URL   string `json:"url"`
+							Title string `json:"title"`
+						} `json:"sources"`
 					} `json:"action"`
 				}
 				if err := json.Unmarshal(event.Item, &wsc); err == nil && wsc.Action.Query != "" {
-					p.lastSearch = llms.SearchActivity{Source: "web", Query: wsc.Action.Query}
+					sources := make([]llms.SearchSource, 0, len(wsc.Action.Sources))
+					for _, source := range wsc.Action.Sources {
+						if source.URL != "" {
+							sources = append(sources, llms.SearchSource{Title: source.Title, URL: source.URL})
+						}
+					}
+					p.lastSearch = llms.SearchActivity{
+						Source:      "web",
+						Query:       wsc.Action.Query,
+						ResultCount: len(sources),
+						Sources:     sources,
+					}
 					if !yield(llms.StreamStatusSearch) {
 						return true
 					}

--- a/openai/responses_xai_hosted_test.go
+++ b/openai/responses_xai_hosted_test.go
@@ -1,0 +1,69 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/llms"
+)
+
+// xaiHostedXSearchSSE mirrors a real xAI Responses stream where the x_search Agent Tool runs
+// its server-side x_user_search sub-tool (a custom_tool_call with call_id prefixed "xs_") and
+// then completes with a final message. Before the fix the turn loop tried to execute
+// x_user_search against the (empty) client toolbox and failed with "tool not found".
+const xaiHostedXSearchSSE = `data: {"type":"response.created","response":{"id":"resp_1"}}
+
+data: {"type":"response.output_item.added","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","input":"","status":"in_progress"},"output_index":1}
+
+data: {"type":"response.custom_tool_call_input.delta","item_id":"ctc_1","delta":"{\"query\":\"paulg\"}"}
+
+data: {"type":"response.custom_tool_call_input.done","item_id":"ctc_1"}
+
+data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","status":"completed"}}
+
+data: {"type":"response.output_item.added","item":{"type":"message","id":"msg_1","status":"in_progress"}}
+
+data: {"type":"response.output_text.delta","item_id":"msg_1","content_index":0,"delta":"Paul Graham co-founded Y Combinator."}
+
+data: {"type":"response.output_item.done","item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Paul Graham co-founded Y Combinator."}]}}
+
+data: {"type":"response.completed"}
+
+`
+
+// The parser must not surface xAI's hosted x_search sub-tool calls as client tool calls.
+func TestResponsesXAIHostedToolCallNotSurfaced(t *testing.T) {
+	stream := &ResponsesStream{ctx: context.Background(), model: "grok-4.3", stream: strings.NewReader(xaiHostedXSearchSSE)}
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+	assert.Empty(t, stream.Message().ToolCalls, "hosted x_search sub-tool calls must not surface as client tool calls")
+}
+
+// The full turn loop must complete with the final message instead of failing "tool not found".
+func TestResponsesXAIHostedToolCallTurnLoop(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, xaiHostedXSearchSSE)
+	}))
+	defer ts.Close()
+
+	llm := llms.New(NewResponsesAPI("k", "grok-4.3").WithEndpoint(ts.URL, "xAI")).WithMaxTurns(1)
+
+	var text strings.Builder
+	for update := range llm.ChatWithContext(context.Background(), "Who is @paulg?") {
+		if tu, ok := update.(llms.TextUpdate); ok {
+			text.WriteString(tu.Text)
+		}
+	}
+
+	require.NoError(t, llm.Err())
+	assert.Contains(t, text.String(), "Y Combinator")
+}

--- a/openai/responses_xai_hosted_test.go
+++ b/openai/responses_xai_hosted_test.go
@@ -22,7 +22,7 @@ const xaiHostedXSearchSSE = `data: {"type":"response.created","response":{"id":"
 
 data: {"type":"response.output_item.added","item":{"type":"web_search_call","id":"ws_1","status":"in_progress","action":{"type":"search","query":"Paul Graham Y Combinator"}}}
 
-data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"Paul Graham Y Combinator"}}}
+data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"Paul Graham Y Combinator","sources":[{"type":"url","url":"https://en.wikipedia.org/wiki/Paul_Graham_(programmer)"},{"type":"url","url":"https://www.paulgraham.com/"}]}}}
 
 data: {"type":"response.output_item.added","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","input":"","status":"in_progress"},"output_index":1}
 
@@ -92,6 +92,14 @@ func TestResponsesXAISearchActivitySurfaced(t *testing.T) {
 
 	require.NoError(t, llm.Err())
 	require.Len(t, searches, 2)
-	assert.Equal(t, llms.SearchActivity{Source: "web", Query: "Paul Graham Y Combinator"}, searches[0])
+	assert.Equal(t, llms.SearchActivity{
+		Source:      "web",
+		Query:       "Paul Graham Y Combinator",
+		ResultCount: 2,
+		Sources: []llms.SearchSource{
+			{URL: "https://en.wikipedia.org/wiki/Paul_Graham_(programmer)"},
+			{URL: "https://www.paulgraham.com/"},
+		},
+	}, searches[0])
 	assert.Equal(t, llms.SearchActivity{Source: "x", Query: "paulg"}, searches[1])
 }

--- a/openai/responses_xai_hosted_test.go
+++ b/openai/responses_xai_hosted_test.go
@@ -20,6 +20,10 @@ import (
 // x_user_search against the (empty) client toolbox and failed with "tool not found".
 const xaiHostedXSearchSSE = `data: {"type":"response.created","response":{"id":"resp_1"}}
 
+data: {"type":"response.output_item.added","item":{"type":"web_search_call","id":"ws_1","status":"in_progress","action":{"type":"search","query":"Paul Graham Y Combinator"}}}
+
+data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"Paul Graham Y Combinator"}}}
+
 data: {"type":"response.output_item.added","item":{"type":"custom_tool_call","id":"ctc_1","call_id":"xs_call-abc-0","name":"x_user_search","input":"","status":"in_progress"},"output_index":1}
 
 data: {"type":"response.custom_tool_call_input.delta","item_id":"ctc_1","delta":"{\"query\":\"paulg\"}"}
@@ -66,4 +70,28 @@ func TestResponsesXAIHostedToolCallTurnLoop(t *testing.T) {
 
 	require.NoError(t, llm.Err())
 	assert.Contains(t, text.String(), "Y Combinator")
+}
+
+// The turn loop must surface the provider-run web_search and x_search as SearchUpdates, carrying
+// their queries, so a UI can show what the model looked up.
+func TestResponsesXAISearchActivitySurfaced(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, xaiHostedXSearchSSE)
+	}))
+	defer ts.Close()
+
+	llm := llms.New(NewResponsesAPI("k", "grok-4.3").WithEndpoint(ts.URL, "xAI")).WithMaxTurns(1)
+
+	var searches []llms.SearchActivity
+	for update := range llm.ChatWithContext(context.Background(), "Who is @paulg?") {
+		if su, ok := update.(llms.SearchUpdate); ok {
+			searches = append(searches, su.SearchActivity)
+		}
+	}
+
+	require.NoError(t, llm.Err())
+	require.Len(t, searches, 2)
+	assert.Equal(t, llms.SearchActivity{Source: "web", Query: "Paul Graham Y Combinator"}, searches[0])
+	assert.Equal(t, llms.SearchActivity{Source: "x", Query: "paulg"}, searches[1])
 }

--- a/openai/websocket_stream.go
+++ b/openai/websocket_stream.go
@@ -49,6 +49,10 @@ func (s *WebSocketStream) Thought() content.Thought {
 	return content.Thought{}
 }
 
+func (s *WebSocketStream) Search() llms.SearchActivity {
+	return s.lastSearch
+}
+
 func (s *WebSocketStream) Usage() llms.Usage {
 	if s.usage == nil {
 		return llms.Usage{}


### PR DESCRIPTION
## What

Adds a `StreamStatusSearch` / `SearchUpdate` path so callers can see the provider-run searches a model performed. The Responses parser now emits a `SearchActivity` (source + query, with fields for result counts and sources) when:

- a `web_search_call` completes — query from its `search` action, and
- a hosted `x_search` sub-call completes — query accumulated from its streamed `custom_tool_call` input. It still is **not** executed as a client tool.

`Search()` is an **optional accessor** read via a type assertion in the turn loop, so only the Responses/WebSocket streams that support it carry it; other providers and the test mocks are untouched (no `ProviderStream` interface change).

## Why

xAI's `web_search` / `x_search` Agent Tools run server-side. The queries the model issued were invisible to callers: `web_search_call` items had no parser case (ignored) and the `x_search` sub-calls were skipped. A UI that wants to show "Searched web: … · N results / Searched X: …" (like Grok's own UI) had nothing to render.

## Supersedes #69

This is built on the x_user_search fix (don't execute xAI's server-side sub-tools as client tools), which #69 carried. Surfacing those sub-calls as *activity* and *not executing* them are the same code path, so they belong in one change. **#69 can be closed in favor of this.** `builder` should pin go.mod to this PR's merge commit.

## Tests

`responses_xai_hosted_test.go`:
- existing: hosted sub-calls don't surface as client tool calls; the turn loop completes instead of failing "tool not found".
- new `TestResponsesXAISearchActivitySurfaced`: a captured stream with a `web_search_call` and a hosted `x_user_search` yields two `SearchUpdate`s — `{web, "Paul Graham Y Combinator"}` and `{x, "paulg"}`.

## Note for reviewers

`ResultCount` / `Sources` are defined on `SearchActivity` but populated only when the provider includes them in the stream. Confirm against a live xAI capture whether `web_search_call` carries result counts/sources before relying on them downstream; the query + source backbone is what this PR guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming event routing and tool-call handling in the Responses parser; mistakes could mis-route deltas or still surface hosted tools for execution, though tests lock in the xAI hosted path.
> 
> **Overview**
> Adds **`StreamStatusSearch`** / **`SearchUpdate`** so chat consumers can show server-side searches (query, source, optional result count and URLs) without executing them. The turn loop maps the status via an optional **`Search()`** type assertion, leaving **`ProviderStream`** unchanged.
> 
> The OpenAI Responses event processor now emits search activity when **`web_search_call`** completes and when hosted **`x_search`** sub-tools finish: **`xs_`** **`custom_tool_call`** items are tracked instead of exposed as client tools, with input deltas routed by item id so hosted queries are not merged into real tool calls. **`ResponsesStream`** and **`WebSocketStream`** implement **`Search()`**; tests cover turn-loop completion and two **`SearchUpdate`**s from a captured xAI stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1051e2ffaaa9ca91366717a1bc134d1a767032bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->