### PR TITLE
[xAI migrate OpenRouter] openai: don't execute hosted x_search tool calls over chat-completions

### DIFF
--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -826,6 +826,13 @@ func cloneThoughtMetadata(in map[string]string) map[string]string {
 func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) {
 	reader := bufio.NewReader(s.stream)
 	var activeToolCallIndex = -1 // Track the index of the tool call being processed
+	// xAI runs its x_search Agent Tool sub-tools (x_user_search, x_keyword_search, ...) server-side
+	// and streams them as tool calls with an "xs_"-prefixed id (e.g. via OpenRouter's chat-completions
+	// passthrough). They are hosted, not client tools, so they are skipped rather than executed.
+	// hostedToolIndices marks which provider tool-call indices are hosted; toolCallLocalIndex maps a
+	// provider index to its position in message.ToolCalls (they diverge once a hosted call is skipped).
+	hostedToolIndices := map[int]bool{}
+	toolCallLocalIndex := map[int]int{}
 	messageStartYielded := false
 
 	return func(rawYield func(llms.StreamStatus) bool) {
@@ -976,11 +983,14 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					}
 				}
 				for _, toolDelta := range delta.ToolCalls {
-					if toolDelta.Index >= len(s.message.ToolCalls) {
-						// This is a new tool call starting
-						if toolDelta.Index != len(s.message.ToolCalls) {
-							s.err = fmt.Errorf("tool call index mismatch: expected %d, got %d", len(s.message.ToolCalls), toolDelta.Index)
-							return
+					localIndex, started := toolCallLocalIndex[toolDelta.Index]
+					if !started && !hostedToolIndices[toolDelta.Index] {
+						// A new tool call starting. A non-empty id is provided on its first delta;
+						// xAI's hosted x_search sub-tools carry an "xs_"-prefixed id and run
+						// server-side, so skip them instead of surfacing them for client execution.
+						if isHostedResponsesToolCall(toolDelta.ID) {
+							hostedToolIndices[toolDelta.Index] = true
+							continue
 						}
 						// If a previous tool call was active, mark it as ready now.
 						if activeToolCallIndex != -1 {
@@ -995,13 +1005,18 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 							return
 						}
 						s.message.ToolCalls = append(s.message.ToolCalls, llmToolCall)
+						localIndex = len(s.message.ToolCalls) - 1
+						toolCallLocalIndex[toolDelta.Index] = localIndex
 						activeToolCallIndex = toolDelta.Index // Mark new tool call as active
 						if !yield(llms.StreamStatusToolCallBegin) {
 							return // Abort if yield fails
 						}
+					} else if hostedToolIndices[toolDelta.Index] {
+						// Hosted search sub-call: ignore its streamed arguments, nothing to run.
+						continue
 					} else {
 						// This is appending arguments to an existing tool call
-						existing := &s.message.ToolCalls[toolDelta.Index]
+						existing := &s.message.ToolCalls[localIndex]
 						if toolDelta.Type != "" {
 							if existing.Metadata == nil {
 								existing.Metadata = make(map[string]string)

--- a/openai/chatcompletions_xai_hosted_test.go
+++ b/openai/chatcompletions_xai_hosted_test.go
@@ -1,0 +1,53 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/llms"
+)
+
+// openRouterHostedXSearchSSE mirrors an OpenRouter chat-completions stream (provider xAI) where the
+// x_search Agent Tool runs its x_user_search sub-tool server-side and streams it as a tool_call with
+// an "xs_"-prefixed id, then continues to the final answer with finish_reason "tool_calls". Without
+// the hosted-tool skip the turn loop tries to execute x_user_search and fails "tool not found".
+const openRouterHostedXSearchSSE = `data: {"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"xs_call-abc-0","type":"function","function":{"name":"x_user_search","arguments":""}}]},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"paulg\"}"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Paul Graham co-founded Y Combinator."},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+
+`
+
+// The turn loop must complete with the final answer instead of trying to run the hosted x_user_search.
+func TestChatCompletionsHostedXSearchNotExecuted(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, openRouterHostedXSearchSSE)
+	}))
+	defer ts.Close()
+
+	llm := llms.New(New("k", "grok-4.3").WithEndpoint(ts.URL, "OpenRouter")).WithMaxTurns(1)
+
+	var text strings.Builder
+	for update := range llm.ChatWithContext(context.Background(), "Who is @paulg?") {
+		if tu, ok := update.(llms.TextUpdate); ok {
+			text.WriteString(tu.Text)
+		}
+	}
+
+	// No error means the hosted x_user_search was skipped, not looked up in the (empty) toolbox.
+	require.NoError(t, llm.Err())
+	assert.Contains(t, text.String(), "Y Combinator")
+}


### PR DESCRIPTION
**Layer 1 of the deferred xAI → OpenRouter migration** (the only piece that's concrete + testable today).

## Why
When grok-4.3 runs via OpenRouter (chat-completions passthrough), xAI's `x_search` runs its sub-tools server-side and streams them as `tool_calls` with an `xs_`-prefixed id, then continues to the final answer with `finish_reason: "tool_calls"`. The chat-completions parser surfaced these as **client** tool calls, so the turn loop did `toolbox.Get("x_user_search")` → nil → `tool "x_user_search" not found`.

This is the **same bug already fixed on the Responses-API path** (#70) — this closes it on the chat-completions path, which is what OpenRouter uses.

Confirmed by a real OpenRouter capture:
```json
"tool_calls":[{"index":0,"id":"xs_call-…","type":"function",
  "function":{"name":"x_user_search","arguments":"{\"query\":\"paulg\"}"}}]
```

## What
- Route tool-call deltas by id: a new tool call whose id is `xs_`-prefixed (hosted) is skipped, and its argument deltas ignored, instead of being added to `message.ToolCalls`.
- Track hosted vs. client indices so local `ToolCalls` positions stay correct once a hosted call is skipped (the old code assumed a 1:1 provider-index ↔ ToolCalls mapping).

## Test
`TestChatCompletionsHostedXSearchNotExecuted` drives a captured OpenRouter `x_user_search` stream through the turn loop; the negative control (skip disabled) reproduces `tool "x_user_search" not found`. Full `openai`+`llms` suite green.

## Not in this PR (the rest of the migration — see the builder RFC)
- Surfacing the hosted x_search query + annotations as a `SearchUpdate` (for the live activity UI).
- Gateway: route grok-4.3 via OpenRouter + `plugins:[{id:"web"}]` + `x_search_filter`.
- Workflow/UI: web-search has no streamed query via OpenRouter (only an aggregate count), so the live "Searched web: …" rows degrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)