### PR TITLE
openai: replay foreign tool calls without item IDs

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -441,6 +441,9 @@ func convertMessageToInput(msg llms.Message) ([]ResponseInput, error) {
 
 		for _, tc := range msg.ToolCalls {
 			itemType := tc.Metadata["openai:item_type"]
+			if itemType == "custom" {
+				return nil, fmt.Errorf("openai responses: replaying Chat Completions custom tool call %q is unsupported", tc.ID)
+			}
 			itemID := ""
 			if itemType == "function_call" || itemType == "custom_tool_call" {
 				itemID = tc.Metadata["openai:item_id"]

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -440,14 +440,23 @@ func convertMessageToInput(msg llms.Message) ([]ResponseInput, error) {
 		flushOutput()
 
 		for _, tc := range msg.ToolCalls {
-			itemID := tc.Metadata["openai:item_id"]
-			if itemID == "" {
-				return nil, fmt.Errorf("tool call %q is missing openai:item_id metadata for replay", tc.ID)
-			}
 			itemType := tc.Metadata["openai:item_type"]
+			itemID := ""
+			if itemType == "function_call" || itemType == "custom_tool_call" {
+				itemID = tc.Metadata["openai:item_id"]
+				if itemID == "" {
+					return nil, fmt.Errorf("Responses API tool call %q is missing openai:item_id metadata for replay", tc.ID)
+				}
+			}
+
+			// Native Responses API output items must retain their original item
+			// IDs. Tool calls from Chat Completions or another provider have no
+			// Responses item identity, so leave ID empty and let the Responses API
+			// treat them as newly supplied history items. call_id still links each
+			// call to its function_call_output.
 			var toolItem ResponseInput
 			switch itemType {
-			case "custom_tool_call":
+			case "custom", "custom_tool_call":
 				toolItem = CustomToolCall{Type: "custom_tool_call", ID: itemID, Name: tc.Name, Input: string(tc.Arguments), CallID: tc.ID}
 			default:
 				toolItem = FunctionCall{Type: "function_call", ID: itemID, Name: tc.Name, Arguments: string(tc.Arguments), CallID: tc.ID}

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -456,7 +456,7 @@ func convertMessageToInput(msg llms.Message) ([]ResponseInput, error) {
 			// call to its function_call_output.
 			var toolItem ResponseInput
 			switch itemType {
-			case "custom", "custom_tool_call":
+			case "custom_tool_call":
 				toolItem = CustomToolCall{Type: "custom_tool_call", ID: itemID, Name: tc.Name, Input: string(tc.Arguments), CallID: tc.ID}
 			default:
 				toolItem = FunctionCall{Type: "function_call", ID: itemID, Name: tc.Name, Arguments: string(tc.Arguments), CallID: tc.ID}

--- a/openai/responses_cross_provider_test.go
+++ b/openai/responses_cross_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/flitsinc/go-llms/content"
 	"github.com/flitsinc/go-llms/llms"
@@ -58,15 +59,18 @@ func crossProviderToolbox() *tools.Toolbox {
 }
 
 func TestResponsesAPI_CrossProviderToolCallReplay(t *testing.T) {
-	var payload map[string]any
+	type capturedRequest struct {
+		payload map[string]any
+		err     error
+	}
+	captured := make(chan capturedRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read request: %v", err)
+		var payload map[string]any
+		if err == nil {
+			err = json.Unmarshal(body, &payload)
 		}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
+		captured <- capturedRequest{payload: payload, err: err}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\"}\n\n")
 	}))
@@ -86,10 +90,14 @@ func TestResponsesAPI_CrossProviderToolCallReplay(t *testing.T) {
 	if err := stream.Err(); err != nil {
 		t.Fatalf("cross-provider replay failed: %v", err)
 	}
+	request := <-captured
+	if request.err != nil {
+		t.Fatalf("capture request: %v", request.err)
+	}
 
-	inputs, ok := payload["input"].([]any)
+	inputs, ok := request.payload["input"].([]any)
 	if !ok {
-		t.Fatalf("expected input array, got %T", payload["input"])
+		t.Fatalf("expected input array, got %T", request.payload["input"])
 	}
 	var functionCall map[string]any
 	var functionOutput map[string]any
@@ -124,12 +132,14 @@ func TestResponsesAPI_CrossProviderToolCallReplayLive(t *testing.T) {
 	if apiKey == "" {
 		t.Skip("OPENAI_API_KEY is not set")
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	stream := NewResponsesAPI(apiKey, "gpt-5.6-luna").
 		WithMaxOutputTokens(128).
 		WithStore(false).
 		Generate(
-			context.Background(),
+			ctx,
 			content.FromText("Reply with exactly OK."),
 			crossProviderReplayMessages(),
 			crossProviderToolbox(),

--- a/openai/responses_cross_provider_test.go
+++ b/openai/responses_cross_provider_test.go
@@ -1,0 +1,143 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/flitsinc/go-llms/tools"
+)
+
+type crossProviderReadParams struct {
+	ModuleName string `json:"module_name" description:"Module name"`
+}
+
+func crossProviderReplayMessages() []llms.Message {
+	return []llms.Message{
+		{Role: "user", Content: content.FromText("Inspect the current module.")},
+		{
+			Role: "assistant",
+			Content: content.Content{
+				&content.Thought{Text: "I need to inspect the module first.", Signature: "foreign-provider-signature"},
+				&content.Text{Text: "I'll inspect the module first."},
+			},
+			ToolCalls: []llms.ToolCall{
+				{
+					ID:        "toolu_01foreign",
+					Name:      "readModule",
+					Arguments: json.RawMessage(`{"module_name":"Main"}`),
+					Metadata:  map[string]string{"openai:item_type": "function"},
+				},
+			},
+		},
+		{
+			Role:       "tool",
+			ToolCallID: "toolu_01foreign",
+			Content:    content.FromText(`{"code":"export default function Main() {}"}`),
+		},
+		{Role: "user", Content: content.FromText("Reply with OK.")},
+	}
+}
+
+func crossProviderToolbox() *tools.Toolbox {
+	readModule := tools.Func(
+		"Read Module",
+		"Read a module",
+		"readModule",
+		func(r tools.Runner, p crossProviderReadParams) tools.Result {
+			return tools.Success(map[string]any{"code": "export default function Main() {}"})
+		},
+	)
+	return tools.Box(readModule)
+}
+
+func TestResponsesAPI_CrossProviderToolCallReplay(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer server.Close()
+
+	stream := NewResponsesAPI("test-key", "gpt-5.6-luna").
+		WithEndpoint(server.URL, "OpenAI").
+		Generate(
+			context.Background(),
+			content.FromText("You are a concise assistant."),
+			crossProviderReplayMessages(),
+			crossProviderToolbox(),
+			nil,
+		)
+	for range stream.Iter() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("cross-provider replay failed: %v", err)
+	}
+
+	inputs, ok := payload["input"].([]any)
+	if !ok {
+		t.Fatalf("expected input array, got %T", payload["input"])
+	}
+	var functionCall map[string]any
+	var functionOutput map[string]any
+	for _, input := range inputs {
+		item, ok := input.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch item["type"] {
+		case "function_call":
+			functionCall = item
+		case "function_call_output":
+			functionOutput = item
+		}
+	}
+	if functionCall == nil || functionOutput == nil {
+		t.Fatalf("expected function call and output in payload: %#v", inputs)
+	}
+	if _, exists := functionCall["id"]; exists {
+		t.Fatalf("foreign function call must not fabricate a Responses item ID: %#v", functionCall)
+	}
+	if functionCall["call_id"] != "toolu_01foreign" {
+		t.Fatalf("unexpected function call ID: %#v", functionCall)
+	}
+	if functionOutput["call_id"] != "toolu_01foreign" {
+		t.Fatalf("tool output lost call linkage: %#v", functionOutput)
+	}
+}
+
+func TestResponsesAPI_CrossProviderToolCallReplayLive(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY is not set")
+	}
+
+	stream := NewResponsesAPI(apiKey, "gpt-5.6-luna").
+		WithMaxOutputTokens(128).
+		WithStore(false).
+		Generate(
+			context.Background(),
+			content.FromText("Reply with exactly OK."),
+			crossProviderReplayMessages(),
+			crossProviderToolbox(),
+			nil,
+		)
+	for range stream.Iter() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("live GPT-5.6 cross-provider replay failed: %v", err)
+	}
+}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -343,27 +343,92 @@ func TestResponsesStream_UsageWithCachedTokens(t *testing.T) {
 	}
 }
 
-func TestConvertMessageToInput_MissingOpenAIItemIDReturnsError(t *testing.T) {
+func TestConvertMessageToInput_ForeignToolCallOmitsResponsesItemID(t *testing.T) {
 	msg := llms.Message{
 		Role: "assistant",
 		Content: content.Content{
-			&content.Thought{ID: "rs_missing", Text: "Planning..."},
+			&content.Thought{Text: "Planning..."},
 		},
+		ToolCalls: []llms.ToolCall{
+			{
+				ID:        "toolu_01foreign",
+				Name:      "run_shell_cmd",
+				Arguments: json.RawMessage(`{"command":"ls"}`),
+				Metadata:  map[string]string{"openai:item_type": "function"},
+			},
+		},
+	}
+
+	items, err := convertMessageToInput(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one function call, got %d (%#v)", len(items), items)
+	}
+	fc, ok := items[0].(FunctionCall)
+	if !ok {
+		t.Fatalf("expected FunctionCall, got %T", items[0])
+	}
+	if fc.ID != "" {
+		t.Fatalf("expected foreign tool call item ID to be omitted, got %q", fc.ID)
+	}
+	if fc.CallID != "toolu_01foreign" {
+		t.Fatalf("expected original call ID to be preserved, got %q", fc.CallID)
+	}
+}
+
+func TestConvertMessageToInput_NativeResponsesToolCallMissingItemIDReturnsError(t *testing.T) {
+	msg := llms.Message{
+		Role: "assistant",
 		ToolCalls: []llms.ToolCall{
 			{
 				ID:        "call_missing",
 				Name:      "run_shell_cmd",
 				Arguments: json.RawMessage(`{"command":"ls"}`),
+				Metadata:  map[string]string{"openai:item_type": "function_call"},
 			},
 		},
 	}
 
 	_, err := convertMessageToInput(msg)
 	if err == nil {
-		t.Fatalf("expected error for tool call missing openai:item_id metadata, got nil")
+		t.Fatal("expected native Responses tool call without an item ID to fail")
 	}
 	if !strings.Contains(err.Error(), "missing openai:item_id metadata") {
 		t.Fatalf("expected missing openai:item_id metadata error, got %v", err)
+	}
+}
+
+func TestConvertMessageToInput_ChatCompletionsCustomToolCallOmitsItemID(t *testing.T) {
+	msg := llms.Message{
+		Role: "assistant",
+		ToolCalls: []llms.ToolCall{
+			{
+				ID:        "call_custom",
+				Name:      "code_exec",
+				Arguments: json.RawMessage(`print("hello")`),
+				Metadata:  map[string]string{"openai:item_type": "custom"},
+			},
+		},
+	}
+
+	items, err := convertMessageToInput(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one custom tool call, got %d (%#v)", len(items), items)
+	}
+	custom, ok := items[0].(CustomToolCall)
+	if !ok {
+		t.Fatalf("expected CustomToolCall, got %T", items[0])
+	}
+	if custom.ID != "" {
+		t.Fatalf("expected Chat Completions custom tool item ID to be omitted, got %q", custom.ID)
+	}
+	if custom.CallID != "call_custom" {
+		t.Fatalf("expected original call ID to be preserved, got %q", custom.CallID)
 	}
 }
 

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -400,38 +400,6 @@ func TestConvertMessageToInput_NativeResponsesToolCallMissingItemIDReturnsError(
 	}
 }
 
-func TestConvertMessageToInput_ChatCompletionsCustomToolCallOmitsItemID(t *testing.T) {
-	msg := llms.Message{
-		Role: "assistant",
-		ToolCalls: []llms.ToolCall{
-			{
-				ID:        "call_custom",
-				Name:      "code_exec",
-				Arguments: json.RawMessage(`print("hello")`),
-				Metadata:  map[string]string{"openai:item_type": "custom"},
-			},
-		},
-	}
-
-	items, err := convertMessageToInput(msg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(items) != 1 {
-		t.Fatalf("expected one custom tool call, got %d (%#v)", len(items), items)
-	}
-	custom, ok := items[0].(CustomToolCall)
-	if !ok {
-		t.Fatalf("expected CustomToolCall, got %T", items[0])
-	}
-	if custom.ID != "" {
-		t.Fatalf("expected Chat Completions custom tool item ID to be omitted, got %q", custom.ID)
-	}
-	if custom.CallID != "call_custom" {
-		t.Fatalf("expected original call ID to be preserved, got %q", custom.CallID)
-	}
-}
-
 func TestConvertMessageToInput_ReasoningPairedWithToolCall(t *testing.T) {
 	msg := llms.Message{
 		Role: "assistant",

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -400,6 +400,24 @@ func TestConvertMessageToInput_NativeResponsesToolCallMissingItemIDReturnsError(
 	}
 }
 
+func TestConvertMessageToInput_ChatCompletionsCustomToolCallReturnsError(t *testing.T) {
+	msg := llms.Message{
+		Role: "assistant",
+		ToolCalls: []llms.ToolCall{
+			{
+				ID:        "call_custom",
+				Name:      "code_exec",
+				Arguments: json.RawMessage(`print("hello")`),
+				Metadata:  map[string]string{"openai:item_type": "custom"},
+			},
+		},
+	}
+
+	if _, err := convertMessageToInput(msg); err == nil {
+		t.Fatal("expected Chat Completions custom tool replay to fail")
+	}
+}
+
 func TestConvertMessageToInput_ReasoningPairedWithToolCall(t *testing.T) {
 	msg := llms.Message{
 		Role: "assistant",


### PR DESCRIPTION
## Summary

- distinguish native Responses tool calls from Chat Completions and foreign-provider history using the structured `openai:item_type` provenance already emitted by go-llms
- preserve and require `openai:item_id` for native Responses items, while omitting the Responses item ID for foreign calls and retaining `call_id` linkage
- add conversion, full wire-payload, and opt-in live GPT-5.6 replay coverage

## Root cause

Cross-provider history can contain a Claude/OpenRouter-style `toolu_…` call with `openai:item_type: "function"` but no Responses item identity. The adapter previously treated every replayed tool call as a native Responses item and failed before sending an HTTP request.

Fabricating an item ID is unnecessary and conflates a new input item with an item returned by the Responses API. The API accepts foreign function-call history without an `id`, while native Responses items still need their original IDs preserved.

This supersedes #52 and the heuristic approach explored in #67.

## Validation

- `go test ./...`
- focused conversion and mock-server replay tests
- real `gpt-5.6-luna` Responses call using the production failure shape (foreign thought signature, `toolu_…` call, tool output, and follow-up user message)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message-to-API conversion for tool-call history; incorrect provenance handling could break native replay or send invalid payloads, but behavior is narrowly scoped and heavily tested.
> 
> **Overview**
> Fixes **cross-provider conversation replay** when switching to the OpenAI Responses API: history that includes foreign tool calls (e.g. `toolu_…` with `openai:item_type: "function"`) no longer fails conversion before the HTTP request.
> 
> `convertMessageToInput` now branches on **`openai:item_type`**: native Responses items (`function_call` / `custom_tool_call`) still **require** `openai:item_id`; foreign or Chat Completions–style calls **omit** the Responses `id` and rely on **`call_id`** to pair with `function_call_output`. **Chat Completions custom** tool replay (`item_type: "custom"`) is explicitly rejected.
> 
> Adds unit tests for conversion edge cases, a mock-server test that asserts the wire payload has no fabricated `id`, and an opt-in live replay test against `gpt-5.6-luna`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8448d906509992a867755bfa8260aa4f6a99bf9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->