### PR TITLE
Expose typed tool argument finalization updates

### DIFF
--- a/llms/llm.go
+++ b/llms/llm.go
@@ -375,6 +375,20 @@ func (l *LLM) turn(ctx context.Context, updateChan chan<- Update) (bool, error) 
 				updateChan <- ToolDeltaUpdate{toolCall.ID, toolCall.Arguments[toolCallDeltaSentBytes:]}
 				toolCallDeltaSentBytes = argLen
 			}
+			var finalArguments json.RawMessage
+			finalizationExpected := false
+			if finalizer, ok := stream.(interface {
+				ToolArgumentFinalization() (json.RawMessage, bool)
+			}); ok {
+				finalArguments, finalizationExpected = finalizer.ToolArgumentFinalization()
+			}
+			if finalizationExpected {
+				update := ToolArgumentFinalizationUpdate{ToolCallID: toolCall.ID}
+				if finalArguments != nil {
+					update.Arguments = append(json.RawMessage{}, finalArguments...)
+				}
+				updateChan <- update
+			}
 			toolMessage := l.runToolCall(ctx, l.toolbox, toolCall, updateChan)
 			toolMessages = append(toolMessages, toolMessage)
 		}

--- a/llms/llm_test.go
+++ b/llms/llm_test.go
@@ -50,6 +50,8 @@ type mockProvider struct {
 	toolboxToolsCount      int
 	toolCallsToMake        []string // Names of tools to simulate calls for on the *first* Generate call
 	processedToolResponses bool     // Tracks if we've seen tool responses in messages
+	finalizationExpected   bool
+	finalArguments         json.RawMessage
 }
 
 func (m *mockProvider) Company() string {
@@ -100,18 +102,22 @@ func (m *mockProvider) Generate(
 	}
 
 	return &mockStream{
-		provider:       m,
-		textToGenerate: textToGenerate,
-		toolCalls:      toolCallsToUse,
+		provider:             m,
+		textToGenerate:       textToGenerate,
+		toolCalls:            toolCallsToUse,
+		finalizationExpected: m.finalizationExpected && !m.processedToolResponses,
+		finalArguments:       m.finalArguments,
 	}
 }
 
 // mockStream is a simple implementation of ProviderStream for testing
 type mockStream struct {
-	provider       *mockProvider
-	textToGenerate string
-	toolCalls      []string
-	message        Message
+	provider             *mockProvider
+	textToGenerate       string
+	toolCalls            []string
+	message              Message
+	finalizationExpected bool
+	finalArguments       json.RawMessage
 }
 
 func (s *mockStream) Err() error { return nil }
@@ -181,6 +187,10 @@ func (s *mockStream) ToolCall() ToolCall {
 		return s.message.ToolCalls[len(s.message.ToolCalls)-1]
 	}
 	return ToolCall{}
+}
+
+func (s *mockStream) ToolArgumentFinalization() (json.RawMessage, bool) {
+	return s.finalArguments, s.finalizationExpected
 }
 
 func (s *mockStream) Usage() Usage {

--- a/llms/llm_tool_execution_test.go
+++ b/llms/llm_tool_execution_test.go
@@ -241,9 +241,12 @@ func TestToolCallInContext(t *testing.T) {
 // tool argument deltas received from the provider stream.
 func TestLLMReceivesToolArgumentDeltas(t *testing.T) {
 	const toolName = "delta_check_tool"
+	providerFinalArguments := json.RawMessage(`{"provider":"final"}`)
 	// Arrange: Mock provider configured to call a specific tool
 	mockProv := &mockProvider{
-		toolCallsToMake: []string{toolName},
+		toolCallsToMake:      []string{toolName},
+		finalizationExpected: true,
+		finalArguments:       providerFinalArguments,
 	}
 
 	// Define the tool that will be called
@@ -263,9 +266,9 @@ func TestLLMReceivesToolArgumentDeltas(t *testing.T) {
 	assert.NoError(t, llm.Err())
 
 	// Assert: Correct number of updates.
-	// Turn 1: InitialText, ToolStart, Delta1, Delta2, ToolDone
+	// Turn 1: InitialText, ToolStart, Delta1, Delta2, ToolArgumentFinalization, ToolDone
 	// Turn 2: FinalText
-	require.Len(t, updates, 6, "Should receive exactly 6 updates for a single tool call with deltas")
+	require.Len(t, updates, 7, "Should receive exactly 7 updates for a single tool call with deltas")
 
 	// Define expected arguments based on mockStream behavior
 	expectedFullArgsStr := fmt.Sprintf(`{"test_param":"test_value_%s"}`, toolName)
@@ -298,9 +301,17 @@ func TestLLMReceivesToolArgumentDeltas(t *testing.T) {
 	assert.Equal(t, receivedToolCallID, deltaUpdate2.ToolCallID, "ToolCallID mismatch in second delta")
 	assert.Equal(t, secondHalfArgs, string(deltaUpdate2.Delta), "Second delta content mismatch")
 
-	// 5. ToolDoneUpdate
-	doneUpdate, ok := updates[4].(ToolDoneUpdate)
-	require.True(t, ok, "Update 4 should be ToolDoneUpdate")
+	// 5. ToolArgumentFinalizationUpdate
+	finalizationUpdate, ok := updates[4].(ToolArgumentFinalizationUpdate)
+	require.True(t, ok, "Update 4 should be ToolArgumentFinalizationUpdate")
+	assert.Equal(t, receivedToolCallID, finalizationUpdate.ToolCallID)
+	assert.Equal(t, providerFinalArguments, finalizationUpdate.Arguments)
+	providerFinalArguments[0] = '!'
+	assert.NotEqual(t, providerFinalArguments, finalizationUpdate.Arguments)
+
+	// 6. ToolDoneUpdate
+	doneUpdate, ok := updates[5].(ToolDoneUpdate)
+	require.True(t, ok, "Update 5 should be ToolDoneUpdate")
 	assert.Equal(t, receivedToolCallID, doneUpdate.ToolCallID, "ToolCallID mismatch in done update")
 	assert.Equal(t, toolName, doneUpdate.Tool.FuncName())
 	require.NoError(t, doneUpdate.Result.Error())
@@ -308,8 +319,8 @@ func TestLLMReceivesToolArgumentDeltas(t *testing.T) {
 	resultJSON := extractJSONFromResult(t, doneUpdate.Result)
 	assert.JSONEq(t, fmt.Sprintf(`{"processed_param":"test_value_%s"}`, toolName), string(resultJSON))
 
-	// 6. Final TextUpdate
-	textUpdate2, ok := updates[5].(TextUpdate)
-	require.True(t, ok, "Update 5 should be TextUpdate")
+	// 7. Final TextUpdate
+	textUpdate2, ok := updates[6].(TextUpdate)
+	require.True(t, ok, "Update 6 should be TextUpdate")
 	assert.Equal(t, "I've processed the results from the tool.", textUpdate2.Text, "Final text mismatch")
 }

--- a/llms/update.go
+++ b/llms/update.go
@@ -23,6 +23,8 @@ const (
 	UpdateTypeSearch       UpdateType = "search"
 )
 
+const UpdateTypeToolArgumentFinalization UpdateType = "tool_argument_finalization"
+
 type Update interface {
 	Type() UpdateType
 }
@@ -39,6 +41,19 @@ func (u ToolStartUpdate) Type() UpdateType {
 type ToolDeltaUpdate struct {
 	ToolCallID string
 	Delta      json.RawMessage
+}
+
+// ToolArgumentFinalizationUpdate carries an independent provider-final
+// argument snapshot. The update is emitted only when the provider protocol is
+// expected to supply such a snapshot. A nil Arguments value means the snapshot
+// was not observed; a non-nil empty value is an observed empty snapshot.
+type ToolArgumentFinalizationUpdate struct {
+	ToolCallID string
+	Arguments  json.RawMessage
+}
+
+func (u ToolArgumentFinalizationUpdate) Type() UpdateType {
+	return UpdateTypeToolArgumentFinalization
 }
 
 func (u ToolDeltaUpdate) Type() UpdateType {

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -279,6 +279,15 @@ func (s *ResponsesStream) ToolCall() llms.ToolCall {
 	return s.message.ToolCalls[len(s.message.ToolCalls)-1]
 }
 
+// ToolArgumentFinalization returns the independent provider-final argument
+// snapshot for the active function call, when the protocol expects one.
+func (s *ResponsesStream) ToolArgumentFinalization() (json.RawMessage, bool) {
+	if s.argumentFinalization == nil {
+		return nil, false
+	}
+	return s.argumentFinalization.arguments, true
+}
+
 func (s *ResponsesStream) Thought() content.Thought {
 	if s.lastThought != nil {
 		return *s.lastThought

--- a/openai/responses_events.go
+++ b/openai/responses_events.go
@@ -13,16 +13,17 @@ import (
 // Responses API streaming events. It is embedded by both ResponsesStream (SSE)
 // and WebSocketStream (WebSocket) to avoid duplicating event-handling code.
 type responsesEventProcessor struct {
-	message           llms.Message
-	lastText          string
-	lastImage         struct{ URL, MIME string }
-	usage             *responsesUsage
-	lastThought       *content.Thought
-	activeToolCall    *llms.ToolCall
-	responseID        string
-	debugger          llms.Debugger
-	err               error
-	processedImageIDs map[string]bool
+	message              llms.Message
+	lastText             string
+	lastImage            struct{ URL, MIME string }
+	usage                *responsesUsage
+	lastThought          *content.Thought
+	activeToolCall       *llms.ToolCall
+	argumentFinalization *toolArgumentFinalization
+	responseID           string
+	debugger             llms.Debugger
+	err                  error
+	processedImageIDs    map[string]bool
 	// lastSearch holds the most recently completed provider-run search (web_search / x_search),
 	// surfaced via StreamStatusSearch so a UI can show what the model looked up.
 	lastSearch llms.SearchActivity
@@ -30,6 +31,10 @@ type responsesEventProcessor struct {
 	// x_user_search / x_keyword_search server-side) by their output item id, so the streamed
 	// query can be accumulated and surfaced once the call completes.
 	hostedSearch map[string]*hostedSearchCall
+}
+
+type toolArgumentFinalization struct {
+	arguments json.RawMessage
 }
 
 // hostedSearchCall accumulates a provider-executed search sub-call until it completes.
@@ -155,6 +160,7 @@ func (p *responsesEventProcessor) processEvent(
 					}
 					p.message.ToolCalls = append(p.message.ToolCalls, llmToolCall)
 					p.activeToolCall = &p.message.ToolCalls[len(p.message.ToolCalls)-1]
+					p.argumentFinalization = &toolArgumentFinalization{}
 					if !yield(llms.StreamStatusToolCallBegin) {
 						return true
 					}
@@ -187,6 +193,7 @@ func (p *responsesEventProcessor) processEvent(
 						}
 						p.activeToolCall = nil
 					}
+					p.argumentFinalization = nil
 					if p.hostedSearch == nil {
 						p.hostedSearch = map[string]*hostedSearchCall{}
 					}
@@ -212,6 +219,7 @@ func (p *responsesEventProcessor) processEvent(
 				}
 				p.message.ToolCalls = append(p.message.ToolCalls, llmToolCall)
 				p.activeToolCall = &p.message.ToolCalls[len(p.message.ToolCalls)-1]
+				p.argumentFinalization = nil
 				if !yield(llms.StreamStatusToolCallBegin) {
 					return true
 				}
@@ -253,6 +261,14 @@ func (p *responsesEventProcessor) processEvent(
 
 	case "response.function_call_arguments.done":
 		if p.activeToolCall != nil {
+			var done struct {
+				Arguments *string `json:"arguments"`
+			}
+			if err := json.Unmarshal(rawJSON, &done); err == nil &&
+				done.Arguments != nil && p.argumentFinalization != nil {
+				p.argumentFinalization.arguments = make(json.RawMessage, len(*done.Arguments))
+				copy(p.argumentFinalization.arguments, *done.Arguments)
+			}
 			if !yield(llms.StreamStatusToolCallReady) {
 				return true
 			}

--- a/openai/websocket_stream.go
+++ b/openai/websocket_stream.go
@@ -42,6 +42,15 @@ func (s *WebSocketStream) ToolCall() llms.ToolCall {
 	return s.message.ToolCalls[len(s.message.ToolCalls)-1]
 }
 
+// ToolArgumentFinalization returns the independent provider-final argument
+// snapshot for the active function call, when the protocol expects one.
+func (s *WebSocketStream) ToolArgumentFinalization() (json.RawMessage, bool) {
+	if s.argumentFinalization == nil {
+		return nil, false
+	}
+	return s.argumentFinalization.arguments, true
+}
+
 func (s *WebSocketStream) Thought() content.Thought {
 	if s.lastThought != nil {
 		return *s.lastThought

--- a/openai/websocket_test.go
+++ b/openai/websocket_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flitsinc/go-llms/content"
 	"github.com/flitsinc/go-llms/llms"
@@ -149,6 +151,88 @@ func TestWebSocketStream_ToolCallStreaming(t *testing.T) {
 	if string(tc.Arguments) != `{"city":"NYC"}` {
 		t.Fatalf("expected arguments '{\"city\":\"NYC\"}', got %q", string(tc.Arguments))
 	}
+}
+
+func TestWebSocketStream_PreservesProviderFinalArgumentsSeparately(t *testing.T) {
+	events := []string{
+		`{"type":"response.created","response":{"id":"resp_tc"}}`,
+		`{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","name":"get_weather","call_id":"call_1","arguments":""}}`,
+		`{"type":"response.function_call_arguments.delta","delta":"{\"city\":\"NYC\"}"}`,
+		`{"type":"response.function_call_arguments.done","arguments":"{\"city\":\"OSL\"}"}`,
+		`{"type":"response.completed"}`,
+	}
+	toolCall, finalArguments, finalizationExpected := captureWebSocketToolArgumentFinalization(t, events)
+	assert.JSONEq(t, `{"city":"NYC"}`, string(toolCall.Arguments))
+	assert.True(t, finalizationExpected)
+	assert.JSONEq(t, `{"city":"OSL"}`, string(finalArguments))
+}
+
+func TestWebSocketStream_DistinguishesMissingAndEmptyProviderFinalArguments(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		doneEvent string
+		wantEmpty bool
+	}{
+		{name: "no finalization event"},
+		{name: "finalization event missing arguments", doneEvent: `{"type":"response.function_call_arguments.done"}`},
+		{name: "observed empty arguments", doneEvent: `{"type":"response.function_call_arguments.done","arguments":""}`, wantEmpty: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			events := []string{
+				`{"type":"response.created","response":{"id":"resp_tc"}}`,
+				`{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","name":"get_weather","call_id":"call_1","arguments":""}}`,
+				`{"type":"response.function_call_arguments.delta","delta":"{\"city\":\"NYC\"}"}`,
+			}
+			if test.doneEvent != "" {
+				events = append(events, test.doneEvent)
+			}
+			events = append(events, `{"type":"response.completed"}`)
+
+			_, finalArguments, finalizationExpected := captureWebSocketToolArgumentFinalization(t, events)
+			assert.True(t, finalizationExpected)
+			if test.wantEmpty {
+				require.NotNil(t, finalArguments)
+				assert.Empty(t, finalArguments)
+				return
+			}
+			assert.Nil(t, finalArguments)
+		})
+	}
+}
+
+func captureWebSocketToolArgumentFinalization(
+	t *testing.T,
+	events []string,
+) (llms.ToolCall, json.RawMessage, bool) {
+	t.Helper()
+	server := newTestWSServer(t, events)
+	t.Cleanup(server.Close)
+
+	provider := NewWebSocketResponsesAPI("test-token", "gpt-5").
+		WithEndpoint(wsEndpoint(server), "Test")
+	t.Cleanup(func() {
+		_ = provider.Close()
+	})
+
+	stream := provider.Generate(
+		context.Background(),
+		content.FromText("You are helpful"),
+		[]llms.Message{{Role: "user", Content: content.FromText("Weather?")}},
+		nil, nil,
+	)
+	var finalArguments json.RawMessage
+	var finalizationExpected bool
+	for status := range stream.Iter() {
+		if status == llms.StreamStatusToolCallReady {
+			finalizer, ok := stream.(interface {
+				ToolArgumentFinalization() (json.RawMessage, bool)
+			})
+			require.True(t, ok)
+			finalArguments, finalizationExpected = finalizer.ToolArgumentFinalization()
+		}
+	}
+	require.NoError(t, stream.Err())
+	return stream.ToolCall(), finalArguments, finalizationExpected
 }
 
 func TestWebSocketStream_ChainingWithPreviousResponseID(t *testing.T) {


### PR DESCRIPTION
## What changed

- Added a typed `ToolArgumentFinalizationUpdate` for provider protocols that expose an independent final tool-argument snapshot.
- Taught OpenAI Responses SSE and WebSocket streams to distinguish unsupported finalization, an expected-but-missing final, an observed empty final, and an available final.
- Preserved the independently assembled tool arguments used for execution; the final snapshot is diagnostic-only.

## Why

Builder needs to compare the authoritative Responses `.done.arguments` value with the deltas emitted by go-llms without reparsing raw provider events through the debugger API. A dedicated update keeps that provider parsing in the canonical Responses adapter and avoids breaking existing `ToolDoneUpdate` composite literals.

## Validation

- `mise exec -- go test ./...`
- `mise exec -- go test -race ./llms ./openai`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive streaming update and optional provider hook; tool execution inputs are unchanged, though UIs that pattern-match on update types may need to handle the new variant.
> 
> **Overview**
> Adds **`ToolArgumentFinalizationUpdate`** so chat consumers can see the provider’s authoritative tool-argument snapshot separately from streamed deltas, without changing what runs tools.
> 
> On **`StreamStatusToolCallReady`**, the turn loop optionally asks the stream for **`ToolArgumentFinalization()`** and emits the new update when the protocol expects a final snapshot. **`nil` `Arguments`** means the snapshot was expected but not observed; a non-nil empty slice means an observed empty final. **`runToolCall`** still uses the delta-assembled **`toolCall.Arguments`** only.
> 
> OpenAI **Responses** (SSE and WebSocket) now track **`response.function_call_arguments.done`** `arguments` in **`argumentFinalization`** for **`function_call`** items, while **`custom_tool_call`** paths clear that state. Tests cover LLM forwarding, argument copying, and WebSocket cases where final args differ from deltas or are missing vs empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fca42ff4aa3d605c8a2ef84dc1feb7a9a9fd2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->