### PR TITLE
Test empty tool argument finalization updates

### DIFF
--- a/llms/llm_tool_execution_test.go
+++ b/llms/llm_tool_execution_test.go
@@ -324,3 +324,33 @@ func TestLLMReceivesToolArgumentDeltas(t *testing.T) {
 	require.True(t, ok, "Update 6 should be TextUpdate")
 	assert.Equal(t, "I've processed the results from the tool.", textUpdate2.Text, "Final text mismatch")
 }
+
+func TestLLMPreservesObservedEmptyToolArgumentFinalization(t *testing.T) {
+	const toolName = "empty_finalization_tool"
+	mockProv := &mockProvider{
+		toolCallsToMake:      []string{toolName},
+		finalizationExpected: true,
+		finalArguments:       json.RawMessage{},
+	}
+	tool := tools.Func(toolName, "Tool for checking empty finalization", toolName,
+		func(r tools.Runner, p TestToolParams) tools.Result {
+			return tools.Success(nil)
+		})
+	llm, _ := setupTestLLM(t, mockProv, tool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	updates := runTestChat(ctx, t, llm, "Check empty tool argument finalization")
+	require.NoError(t, llm.Err())
+
+	for _, update := range updates {
+		finalization, ok := update.(ToolArgumentFinalizationUpdate)
+		if !ok {
+			continue
+		}
+		require.NotNil(t, finalization.Arguments)
+		assert.Empty(t, finalization.Arguments)
+		return
+	}
+	t.Fatal("expected ToolArgumentFinalizationUpdate")
+}


### PR DESCRIPTION
## Summary

- add an end-to-end LLM update regression test for an observed empty provider-final tool-argument snapshot
- verify the emitted `ToolArgumentFinalizationUpdate.Arguments` remains non-nil while containing zero bytes

## Why

Builder distinguishes a missing provider-final snapshot (`nil`) from a snapshot that was observed but empty (non-nil, zero length). This protects that typed contract across the real provider-to-LLM update path instead of testing only the update struct.

## Validation

- `mise exec -- go test ./...`
- `mise exec -- go test -race ./llms ./openai`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **`TestLLMPreservesObservedEmptyToolArgumentFinalization`**, an end-to-end LLM chat test that drives the mock provider with **`finalArguments: json.RawMessage{}`** and **`finalizationExpected: true`**.
> 
> The test asserts the stream emits a **`ToolArgumentFinalizationUpdate`** whose **`Arguments`** field is **non-nil** but **zero-length**, locking in the distinction between “no provider-final snapshot” (`nil`) and “provider sent an empty final snapshot” (non-nil empty slice) on the real provider→LLM update path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f15cb189f15a16b255f8f077383125b9b6550a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->