### PR TITLE
Fix encrypted reasoning on OpenAI models via OpenRouter

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -718,14 +717,9 @@ func (s *Stream) Iter() func(yield func(llms.StreamStatus) bool) {
 					}
 				case "redacted_thinking":
 					if event.ContentBlock.Data != "" {
-						decodedData, err := base64.StdEncoding.DecodeString(event.ContentBlock.Data)
-						if err != nil {
-							s.err = fmt.Errorf("error decoding redacted_thinking data: %w", err)
-							return
-						}
 						thought := &content.Thought{
 							Text:      "(Redacted)",
-							Encrypted: decodedData,
+							Encrypted: event.ContentBlock.Data,
 							Summary:   true,
 						}
 						s.lastThought = thought
@@ -901,9 +895,9 @@ func contentFromLLM(llmContent content.Content) (contentList, error) {
 			ci.Type = "text"
 			ci.Text = string(v.Data)
 		case *content.Thought:
-			if len(v.Encrypted) > 0 {
+			if v.Encrypted != "" {
 				ci.Type = "redacted_thinking"
-				ci.Data = base64.StdEncoding.EncodeToString(v.Encrypted)
+				ci.Data = v.Encrypted
 			} else {
 				ci.Type = "thinking"
 				ci.Thinking = v.Text

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -454,6 +454,43 @@ func TestAnthropicStreamHandling(t *testing.T) {
 	})
 }
 
+// TestAnthropicRedactedThinkingRoundTrip pins the redacted_thinking "data" blob
+// as an opaque token: Anthropic has to receive on replay exactly the string it
+// sent, so the stream stores it as-is instead of decoding and re-encoding it.
+// The fixture is deliberately not decodable as standard base64, so reintroducing
+// a decode/re-encode step fails here instead of silently corrupting the token.
+func TestAnthropicRedactedThinkingRoundTrip(t *testing.T) {
+	const token = "EroBCkYIBBgCKkDvRedacted_Thinking-BlobEgz"
+
+	var streamContent strings.Builder
+	streamContent.WriteString(sseEvent(streamEvent{
+		Type:    "message_start",
+		Message: &messageEvent{Role: "assistant"},
+	}))
+	streamContent.WriteString(sseEvent(streamEvent{
+		Type:         "content_block_start",
+		Index:        0,
+		ContentBlock: &contentBlock{Type: "redacted_thinking", Data: token},
+	}))
+	streamContent.WriteString(sseEvent(streamEvent{Type: "content_block_stop", Index: 0}))
+	streamContent.WriteString(sseEvent(streamEvent{Type: "message_stop"}))
+
+	stream := newTestAnthropicStream(context.Background(), "claude-opus-4-6", streamContent.String())
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+
+	thought, ok := stream.Message().Content[0].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, token, thought.Encrypted)
+
+	apiContent, err := contentFromLLM(stream.Message().Content)
+	require.NoError(t, err)
+	require.Len(t, apiContent, 1)
+	assert.Equal(t, "redacted_thinking", apiContent[0].Type)
+	assert.Equal(t, token, apiContent[0].Data)
+}
+
 func TestContentFromLLMEdgeCases(t *testing.T) {
 	t.Run("Empty Text Content", func(t *testing.T) {
 		llmContent := content.FromText("")

--- a/content/content.go
+++ b/content/content.go
@@ -89,9 +89,16 @@ func (j *JSON) Type() Type {
 }
 
 type Thought struct {
-	ID        string `json:"id,omitempty"`
-	Text      string `json:"text,omitempty"`
-	Encrypted []byte `json:"encrypted,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Text string `json:"text,omitempty"`
+	// Encrypted is the provider's opaque encrypted-reasoning token exactly as it
+	// appeared on the wire (Anthropic's redacted_thinking "data", OpenRouter's
+	// reasoning.encrypted "data"). It is replayed verbatim, because the token's
+	// encoding belongs to the upstream that issued it: Anthropic sends standard
+	// base64, while OpenAI Responses blobs relayed by OpenRouter are URL-safe
+	// base64 Fernet tokens. Decoding one alphabet and re-encoding as the other
+	// both rejects valid tokens and hands the upstream a token it cannot decrypt.
+	Encrypted string `json:"encrypted,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	// Metadata holds protocol-specific metadata that should be forwarded unchanged.
 	// Keys are prefixed with the protocol/provider name, e.g. "openai:format".
@@ -178,7 +185,7 @@ func (c *Content) Append(text string) {
 // otherwise it adds a new thought item to the end of the list.
 func (c *Content) AppendThought(text string) {
 	if l := len(*c); l > 0 {
-		if tc, ok := (*c)[l-1].(*Thought); ok && len(tc.Encrypted) == 0 {
+		if tc, ok := (*c)[l-1].(*Thought); ok && tc.Encrypted == "" {
 			tc.Text += text
 			return
 		}
@@ -212,7 +219,7 @@ func (c *Content) AppendThoughtWithID(id, text string, summary bool) *Thought {
 // otherwise it adds a new thought item to the end of the list.
 func (c *Content) SetThoughtSummary(text, signature string) {
 	if l := len(*c); l > 0 {
-		if tc, ok := (*c)[l-1].(*Thought); ok && len(tc.Encrypted) == 0 {
+		if tc, ok := (*c)[l-1].(*Thought); ok && tc.Encrypted == "" {
 			tc.Text = text
 			tc.Signature = signature
 			tc.Summary = true

--- a/llms/before_response.go
+++ b/llms/before_response.go
@@ -155,7 +155,7 @@ func cloneContent(c content.Content) content.Content {
 			out = append(out, &content.Thought{
 				ID:        v.ID,
 				Text:      v.Text,
-				Encrypted: append([]byte(nil), v.Encrypted...),
+				Encrypted: v.Encrypted,
 				Signature: v.Signature,
 				Metadata:  cloneMetadata(v.Metadata),
 				Summary:   v.Summary,

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -928,20 +928,24 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 			}
 			// Handle reasoning/thinking tokens from providers that include them
 			// in the OpenAI-compatible streaming format. delta.Reasoning is the
-			// legacy plaintext field; reasoning_details carries structured replay data.
-			if delta.Reasoning != nil && *delta.Reasoning != "" {
+			// legacy plaintext field; reasoning_details carries structured replay
+			// data. OpenRouter sends both, with the same text in each, so a chunk
+			// that has details takes them as the only source: emitting the legacy
+			// field as well duplicates every thinking token and, worse, adds an
+			// untyped reasoning.text detail to the replayed message that upstreams
+			// reject (OpenAI's Responses API refuses a reasoning item that carries
+			// both encrypted content and a content array).
+			if len(delta.ReasoningDetails) > 0 {
+				for _, rd := range delta.ReasoningDetails {
+					if !s.emitReasoningDetail(rd, yield) {
+						return
+					}
+				}
+			} else if delta.Reasoning != nil && *delta.Reasoning != "" {
 				if !s.emitReasoningDetail(ReasoningDetail{
 					Type: "reasoning.text",
 					Text: *delta.Reasoning,
 				}, yield) {
-					return
-				}
-			}
-			for _, rd := range delta.ReasoningDetails {
-				if delta.Reasoning != nil && *delta.Reasoning != "" && rd.Text != "" {
-					rd.Text = ""
-				}
-				if !s.emitReasoningDetail(rd, yield) {
 					return
 				}
 			}

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -645,11 +645,7 @@ func (s *ChatCompletionsStream) emitReasoningDetail(
 	rd ReasoningDetail,
 	yield func(llms.StreamStatus) bool,
 ) bool {
-	thought, err := s.applyReasoningDetail(rd)
-	if err != nil {
-		s.err = err
-		return false
-	}
+	thought := s.applyReasoningDetail(rd)
 	if thought == nil {
 		return true
 	}
@@ -657,7 +653,7 @@ func (s *ChatCompletionsStream) emitReasoningDetail(
 	return yield(llms.StreamStatusThinking)
 }
 
-func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*content.Thought, error) {
+func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) *content.Thought {
 	aggregate := s.findReasoningThought(rd)
 	if aggregate == nil {
 		aggregate = &content.Thought{ID: rd.ID}
@@ -670,18 +666,12 @@ func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*conte
 	switch rd.Type {
 	case "reasoning.encrypted":
 		if rd.Data == "" && rd.Signature == "" {
-			return nil, nil
+			return nil
 		}
-		var deltaEncrypted []byte
 		if rd.Data != "" {
-			decodedData, err := base64.StdEncoding.DecodeString(rd.Data)
-			if err != nil {
-				return nil, fmt.Errorf("error decoding encrypted reasoning data: %w", err)
-			}
-			aggregate.Encrypted = decodedData
+			aggregate.Encrypted = rd.Data
 			aggregate.Text = "(Redacted)"
 			aggregate.Summary = true
-			deltaEncrypted = append([]byte(nil), decodedData...)
 		}
 		if rd.Signature != "" {
 			aggregate.Signature = rd.Signature
@@ -689,14 +679,14 @@ func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*conte
 		return &content.Thought{
 			ID:        aggregate.ID,
 			Text:      aggregate.Text,
-			Encrypted: deltaEncrypted,
+			Encrypted: rd.Data,
 			Signature: rd.Signature,
 			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
 			Summary:   aggregate.Summary,
-		}, nil
+		}
 	case "reasoning.summary":
 		if rd.Summary == "" && rd.Signature == "" {
-			return nil, nil
+			return nil
 		}
 		aggregate.Summary = true
 		aggregate.Text += rd.Summary
@@ -709,10 +699,10 @@ func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*conte
 			Signature: rd.Signature,
 			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
 			Summary:   true,
-		}, nil
+		}
 	default:
 		if rd.Text == "" && rd.Signature == "" {
-			return nil, nil
+			return nil
 		}
 		aggregate.Text += rd.Text
 		if rd.Signature != "" {
@@ -724,7 +714,7 @@ func (s *ChatCompletionsStream) applyReasoningDetail(rd ReasoningDetail) (*conte
 			Signature: rd.Signature,
 			Metadata:  cloneThoughtMetadata(aggregate.Metadata),
 			Summary:   aggregate.Summary,
-		}, nil
+		}
 	}
 }
 
@@ -804,11 +794,11 @@ func thoughtMatchesReasoningDetail(thought *content.Thought, rd ReasoningDetail)
 	}
 	switch rd.Type {
 	case "reasoning.encrypted":
-		return len(thought.Encrypted) > 0
+		return thought.Encrypted != ""
 	case "reasoning.summary":
-		return thought.Summary && len(thought.Encrypted) == 0
+		return thought.Summary && thought.Encrypted == ""
 	default:
-		return !thought.Summary && len(thought.Encrypted) == 0
+		return !thought.Summary && thought.Encrypted == ""
 	}
 }
 

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -728,7 +728,10 @@ func TestBuildPayload_WithPromptCacheRetention_SentToCustomEndpointWhenExplicit(
 }
 
 func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
-	encrypted := base64.StdEncoding.EncodeToString([]byte("encrypted-reasoning"))
+	// A URL-safe base64 token, the shape OpenAI's Responses reasoning blobs take
+	// when OpenRouter relays them: it is not decodable as standard base64, and it
+	// must reach the next request byte for byte.
+	const encrypted = "gAAAAABqccT0GkPaBas6YYMfXhseiAeD64kXBk_j5VUy2r2InH9o7tzAzuFF-Q=="
 	sse := strings.Join([]string{
 		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
 		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","text":"Hello ","format":"anthropic-claude-v1","index":0}]}}]}`,
@@ -766,7 +769,7 @@ func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
 
 	assert.Equal(t, "r2", thoughts[2].ID)
 	assert.Equal(t, "(Redacted)", thoughts[2].Text)
-	assert.Equal(t, []byte("encrypted-reasoning"), thoughts[2].Encrypted)
+	assert.Equal(t, encrypted, thoughts[2].Encrypted)
 	assert.Equal(t, "enc-sig", thoughts[2].Signature)
 	assert.True(t, thoughts[2].Summary)
 	assert.Equal(t, "1", thoughts[2].Metadata["openai:reasoning_index"])
@@ -789,7 +792,7 @@ func TestChatCompletionsStream_ReasoningDetailsDeltaAndAggregate(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "r2", secondThought.ID)
 	assert.Equal(t, "(Redacted)", secondThought.Text)
-	assert.Equal(t, []byte("encrypted-reasoning"), secondThought.Encrypted)
+	assert.Equal(t, encrypted, secondThought.Encrypted)
 	assert.Equal(t, "enc-sig", secondThought.Signature)
 	assert.True(t, secondThought.Summary)
 	assert.Equal(t, "1", secondThought.Metadata["openai:reasoning_index"])
@@ -845,13 +848,12 @@ func TestChatCompletionsStream_ApplyReasoningDetail_DoesNotMatchDifferentIDByInd
 		},
 	}
 
-	thought, err := stream.applyReasoningDetail(ReasoningDetail{
+	thought := stream.applyReasoningDetail(ReasoningDetail{
 		Type:  "reasoning.text",
 		ID:    "r2",
 		Index: intPtr(0),
 		Text:  "new",
 	})
-	require.NoError(t, err)
 	require.NotNil(t, thought)
 	assert.Equal(t, "r2", thought.ID)
 	assert.Equal(t, "new", thought.Text)
@@ -891,7 +893,7 @@ func TestBuildPayload_WithCacheControlPromptHintsAndAssistantReasoningReplay(t *
 				&content.Thought{
 					ID:        "t2",
 					Text:      "(Redacted)",
-					Encrypted: []byte("secret"),
+					Encrypted: "gAAAAABopaque-token_-",
 					Summary:   true,
 					Metadata:  map[string]string{"openai:reasoning_index": "1"},
 				},
@@ -1004,6 +1006,43 @@ func TestDoRequest_OpenRouterErrorMetadata(t *testing.T) {
 	assert.Equal(t, json.RawMessage(`{"error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}`), httpErr.Metadata.Raw)
 	assert.Equal(t, "invalid_request_error", httpErr.Metadata.RawErrorType)
 	assert.Equal(t, "prompt is too long: 250000 tokens > 200000 maximum", httpErr.Metadata.RawErrorMessage)
+}
+
+// TestChatCompletionsStream_EncryptedReasoningReplaysVerbatim covers the full
+// round trip for an OpenAI Responses reasoning blob relayed by OpenRouter: the
+// token arrives as URL-safe base64 (a Fernet token, which standard base64 cannot
+// decode), and the assistant replay has to hand the exact same string back so the
+// upstream can decrypt it.
+func TestChatCompletionsStream_EncryptedReasoningReplaysVerbatim(t *testing.T) {
+	const token = "gAAAAABqccT0GkPaBas6YYMfXhseiAeD64kXBk_j5VUy2r2InH9o7tzAzuFF-Q=="
+	_, err := base64.StdEncoding.DecodeString(token)
+	require.Error(t, err, "fixture must not be decodable as standard base64")
+
+	sse := strings.Join([]string{
+		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning_details":[{"type":"reasoning.encrypted","id":"rs_1","data":"` + token + `","format":"openai-responses-v1","index":0}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"content":"42"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+
+	replayed, err := NewChatCompletionsAPI("", "test-model").
+		WithAssistantReasoningReplay().
+		BuildPayload(nil, []llms.Message{stream.Message()}, nil, nil)
+	require.NoError(t, err)
+
+	messages := replayed["messages"].([]Message)
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ReasoningDetails, 1)
+	detail := messages[0].ReasoningDetails[0]
+	assert.Equal(t, "reasoning.encrypted", detail.Type)
+	assert.Equal(t, token, detail.Data)
+	assert.Equal(t, "openai-responses-v1", detail.Format)
 }
 
 func intPtr(v int) *int {

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -1045,6 +1045,65 @@ func TestChatCompletionsStream_EncryptedReasoningReplaysVerbatim(t *testing.T) {
 	assert.Equal(t, "openai-responses-v1", detail.Format)
 }
 
+// TestChatCompletionsStream_LegacyReasoningFieldDeduped covers OpenRouter's habit
+// of sending the same reasoning twice per chunk: once in the legacy "reasoning"
+// string and once as a structured reasoning_details entry. Only the structured
+// form may reach the message, or the thinking text is doubled on screen and the
+// replayed assistant message grows an extra reasoning.text detail.
+func TestChatCompletionsStream_LegacyReasoningFieldDeduped(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning":"Solving ","reasoning_details":[{"type":"reasoning.summary","summary":"Solving ","format":"openai-responses-v1","index":0}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning":"it.","reasoning_details":[{"type":"reasoning.summary","summary":"it.","format":"openai-responses-v1","index":0}]}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"content":"42"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+	for range stream.Iter() {
+	}
+	require.NoError(t, stream.Err())
+
+	msg := stream.Message()
+	require.Len(t, msg.Content, 2)
+	thought, ok := msg.Content[0].(*content.Thought)
+	require.True(t, ok)
+	assert.Equal(t, "Solving it.", thought.Text)
+
+	replayed, err := NewChatCompletionsAPI("", "test-model").
+		WithAssistantReasoningReplay().
+		BuildPayload(nil, []llms.Message{msg}, nil, nil)
+	require.NoError(t, err)
+	messages := replayed["messages"].([]Message)
+	require.Len(t, messages[0].ReasoningDetails, 1)
+	assert.Equal(t, "reasoning.summary", messages[0].ReasoningDetails[0].Type)
+	assert.Equal(t, "Solving it.", messages[0].ReasoningDetails[0].Summary)
+}
+
+// TestChatCompletionsStream_LegacyReasoningFieldAloneStillStreams keeps the
+// legacy path alive for providers that only send the plain "reasoning" string.
+func TestChatCompletionsStream_LegacyReasoningFieldAloneStillStreams(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"id":"chat_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"reasoning":"Thinking hard."}}]}`,
+		`data: {"id":"chat_1","choices":[{"delta":{"content":"42"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+	var thoughts []content.Thought
+	for status := range stream.Iter() {
+		if status == llms.StreamStatusThinking {
+			thoughts = append(thoughts, stream.Thought())
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, thoughts, 1)
+	assert.Equal(t, "Thinking hard.", thoughts[0].Text)
+}
+
 func intPtr(v int) *int {
 	return &v
 }

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -368,9 +367,9 @@ func reasoningDetailsFromContent(c content.Content) []ReasoningDetail {
 			detail.Index = &idx
 		}
 		switch {
-		case len(t.Encrypted) > 0:
+		case t.Encrypted != "":
 			detail.Type = "reasoning.encrypted"
-			detail.Data = base64.StdEncoding.EncodeToString(t.Encrypted)
+			detail.Data = t.Encrypted
 		case t.Summary:
 			detail.Type = "reasoning.summary"
 			detail.Summary = t.Text
@@ -466,7 +465,7 @@ type ReasoningDetail struct {
 	ID        string `json:"id,omitempty"`        // stable identifier for replaying a logical reasoning block
 	Summary   string `json:"summary,omitempty"`   // summary text for reasoning.summary blocks
 	Text      string `json:"text,omitempty"`      // reasoning text (streamed per chunk)
-	Data      string `json:"data,omitempty"`      // base64-encoded encrypted thinking
+	Data      string `json:"data,omitempty"`      // opaque encrypted reasoning token, replayed verbatim
 	Signature string `json:"signature,omitempty"` // Anthropic signature (final chunk only)
 	Format    string `json:"format,omitempty"`    // e.g. "anthropic-claude-v1"
 	Index     *int   `json:"index,omitempty"`

--- a/openrouter/openrouter_test.go
+++ b/openrouter/openrouter_test.go
@@ -33,7 +33,7 @@ func TestNew_BuildPayload_UsesOpenRouterEncoding(t *testing.T) {
 				&content.Thought{
 					ID:        "t2",
 					Text:      "(Redacted)",
-					Encrypted: []byte("secret"),
+					Encrypted: "gAAAAABopaque-token_-",
 					Summary:   true,
 					Metadata:  map[string]string{"openai:reasoning_format": "anthropic-claude-v1", "openai:reasoning_index": "1"},
 				},
@@ -81,7 +81,7 @@ func TestNew_BuildPayload_UsesOpenRouterEncoding(t *testing.T) {
 	second := reasoningDetails[1].(map[string]any)
 	assert.Equal(t, "reasoning.encrypted", second["type"])
 	assert.Equal(t, "t2", second["id"])
-	assert.NotEmpty(t, second["data"])
+	assert.Equal(t, "gAAAAABopaque-token_-", second["data"])
 
 	third := reasoningDetails[2].(map[string]any)
 	assert.Equal(t, "reasoning.text", third["type"])


### PR DESCRIPTION
`openrouter/openai/gpt-5.6-luna` (and any OpenAI model routed through OpenRouter) dies mid-stream:

```
error iterating stream: error decoding encrypted reasoning data: illegal base64 data at input byte 37
```

Two separate bugs, both confirmed against the live OpenRouter API and both fixed here.

## 1. `reasoning.encrypted` data is not standard base64

OpenRouter relays OpenAI's Responses reasoning blob verbatim in `reasoning_details[].data`. That blob is a Fernet token (`gAAAAABqccT0GkPaBas6YYMfXhseiAeD64kXBk_j5VUy...`) in **URL-safe** base64, so `base64.StdEncoding` hits the first `-`/`_` a few dozen bytes in and fails the turn. Measured on a live call: first non-standard character at index 38, `format: "openai-responses-v1"`.

The decode was never load-bearing. Both Anthropic's `redacted_thinking` data and OpenRouter's `reasoning.encrypted` data are opaque tokens that must return to the upstream byte for byte, so `content.Thought.Encrypted` is now the wire string itself (`string`, not `[]byte`), stored and replayed verbatim. For standard-base64 tokens the JSON shape is unchanged — `[]byte` already marshalled as standard base64 — so anything callers persisted still round-trips.

## 2. The same reasoning was emitted twice per chunk

For OpenAI models OpenRouter fills **both** the legacy `delta.reasoning` string and a structured `reasoning_details` entry with the same text (measured: 100 of 101 chunks carried both). We emitted both, which doubled every thinking token on screen and added an extra untyped `reasoning.text` thought to the replayed assistant message. On the next turn OpenAI rejected it:

```
Invalid 'input[1].content': array too long. Expected an array with maximum length 0, but got an array with length 1 instead.
```

The old guard only blanked a duplicate `rd.Text`; the OpenAI format carries its text in `rd.Summary` instead, so it slipped through. Structured details now win for any chunk that has them, and the legacy field is still read for providers that send nothing else.

## Verification

- `go test ./...` green.
- New tests: verbatim replay of a URL-safe token, Anthropic `redacted_thinking` round trip, legacy/structured dedup, and legacy-only streaming. The dedup test fails against the old implementation.
- Live end-to-end against OpenRouter with `openai/gpt-5.6-luna`: `go run main.go openrouter-thinking openai/gpt-5.6-luna` panicked on `main` and now completes a two-turn tool conversation, with the replayed request carrying exactly the `reasoning.summary` + `reasoning.encrypted` pair the provider sent, data byte-identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reasoning replay across Anthropic, OpenAI Chat Completions, and OpenRouter; `Encrypted` type change affects any persisted messages, though JSON shape for standard base64 remains compatible.
> 
> **Overview**
> Fixes **OpenRouter / OpenAI reasoning** failures by treating provider encrypted-reasoning blobs as **opaque strings** instead of decoding and re-encoding them.
> 
> **`content.Thought.Encrypted`** is now a `string` holding the wire token exactly (Anthropic `redacted_thinking` data, OpenRouter `reasoning.encrypted` data). Anthropic and Chat Completions paths **store and replay** that string without `base64` transforms, so URL-safe Fernet-style tokens from OpenRouter no longer break mid-stream and upstreams can decrypt on the next turn.
> 
> **Chat Completions streaming** prefers **`reasoning_details`** when present and only falls back to legacy `delta.reasoning` when there are no details—avoiding doubled thinking text and extra `reasoning.text` replay entries that OpenAI’s Responses API rejects.
> 
> Tests cover verbatim encrypted round-trips, legacy vs structured dedup, and legacy-only streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadcd860ed4de5ef261590ddd1b515315b24bf2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->