### PR TITLE
Replay custom tool call results and tool_choice with their declared type

### DIFF
--- a/integration_grammar_test.go
+++ b/integration_grammar_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/flitsinc/go-llms/openrouter"
+	"github.com/flitsinc/go-llms/tools"
+)
+
+const integrationPatchGrammar = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+%import common.LF`
+
+// requestRecorder captures every raw provider request so the test can assert
+// what actually went over the wire on each turn.
+type requestRecorder struct {
+	mu       sync.Mutex
+	requests []string
+}
+
+func (r *requestRecorder) RawRequest(endpoint string, data []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, string(data))
+}
+
+func (r *requestRecorder) RawEvent([]byte) {}
+
+// TestIntegration_OpenRouterFlatCustomGrammarTool runs a Lark-grammar custom
+// tool through the full client against live OpenRouter (openai/gpt-5.6-luna),
+// covering the whole flat-custom-tools surface in one two-turn conversation:
+//
+//   - declaration: the flat Responses-style custom tool + forced tool_choice
+//     are accepted (the nested Chat Completions wrapper is rejected upstream);
+//   - generation: the streamed tool input is raw grammar-conformant text,
+//     delivered incrementally, and constrained decoding is genuinely applied;
+//   - replay: the follow-up request carries the assistant call's raw
+//     arguments verbatim — the review-found bug was these being sanitized to
+//     "{}" — and the upstream accepts the replayed call + result.
+func TestIntegration_OpenRouterFlatCustomGrammarTool(t *testing.T) {
+	key := os.Getenv("OPENROUTER_API_KEY")
+	if key == "" {
+		t.Skip("OPENROUTER_API_KEY required")
+	}
+
+	var toolInputs []string
+	deltaCount := 0
+	patchTool := tools.FuncGrammar(
+		tools.Lark(integrationPatchGrammar),
+		"apply_patch",
+		"Create files by emitting a patch. The input is the raw patch text, not JSON.",
+		"apply_patch",
+		func(r tools.Runner, input string) tools.Result {
+			toolInputs = append(toolInputs, input)
+			return tools.SuccessFromString("created")
+		},
+	)
+
+	recorder := &requestRecorder{}
+	llm := llms.New(openrouter.New(key, "openai/gpt-5.6-luna"), patchTool).
+		WithMaxTurns(2).
+		WithDebugger(recorder)
+	llm.SystemPrompt = func() content.Content {
+		return content.FromText("You create files using the apply_patch tool.")
+	}
+	llm.SetToolChoice(tools.Choice{Mode: tools.ChoiceRequireOneOf, AllowedTools: []string{"apply_patch"}})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for update := range llm.Chat("Create hello.txt containing the single line: hi from the integration test") {
+			if _, ok := update.(llms.ToolDeltaUpdate); ok {
+				deltaCount++
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(120 * time.Second):
+		t.Fatal("conversation did not complete within 120s")
+	}
+	if err := llm.Err(); err != nil {
+		require.ErrorIs(t, err, llms.ErrMaxTurnsReached, "only the max-turns stop condition is acceptable")
+	}
+
+	// Generation: raw, grammar-conformant, streamed incrementally.
+	require.NotEmpty(t, toolInputs, "the forced tool must have executed")
+	firstInput := toolInputs[0]
+	assert.True(t, strings.HasPrefix(firstInput, "*** Begin Patch\n"),
+		"tool input must be the raw patch text, got %q", firstInput)
+	assert.Contains(t, firstInput, "*** Add File: ")
+	assert.False(t, strings.HasPrefix(firstInput, "{"), "input must not be JSON-wrapped")
+	assert.Greater(t, deltaCount, 1, "input must stream as incremental deltas")
+
+	// Wire: turn 1 declares the flat custom tool; turn 2 replays the call's
+	// raw arguments verbatim instead of sanitizing them to "{}".
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	require.GreaterOrEqual(t, len(recorder.requests), 2, "expected a request per turn")
+	turn1, turn2 := recorder.requests[0], recorder.requests[len(recorder.requests)-1]
+	assert.Contains(t, turn1, `"type":"custom"`, "turn 1 must declare the custom tool")
+	assert.Contains(t, turn1, `"syntax":"lark"`)
+	assert.NotContains(t, turn1, `"custom":{`, "flat mode must not emit the nested wrapper")
+	assert.Contains(t, turn2, "*** Add File: ", "turn 2 must replay the raw patch arguments")
+	assert.NotContains(t, turn2, `"arguments":"{}"`, "raw arguments must not be sanitized away on replay")
+
+	t.Logf("turn-1 tool input (%d deltas):\n%s", deltaCount, firstInput)
+}

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -187,6 +187,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 	encodingOptions := chatMessageEncodingOptions{
 		cacheControlPromptHints:  m.cacheControlPromptHints,
 		assistantReasoningReplay: m.assistantReasoningReplay,
+		flatCustomTools:          m.flatCustomTools,
 	}
 
 	var apiMessages []Message

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -34,6 +34,9 @@ type ChatCompletionsAPI struct {
 
 	// When true, encode CacheHint items as cache_control on content parts.
 	cacheControlPromptHints bool
+	// When true, declare custom tools in the flat Responses-API shape and
+	// reference them the same way in tool_choice (see WithFlatCustomTools).
+	flatCustomTools bool
 	// When true, encode assistant Thought items as reasoning_details for replay.
 	assistantReasoningReplay bool
 
@@ -94,6 +97,19 @@ func (m *ChatCompletionsAPI) WithIncludeUsage(include bool) *ChatCompletionsAPI 
 // content parts instead of using prompt_cache_retention.
 func (m *ChatCompletionsAPI) WithCacheControlPromptHints() *ChatCompletionsAPI {
 	m.cacheControlPromptHints = true
+	return m
+}
+
+// WithFlatCustomTools declares custom (grammar/text) tools in the flat
+// Responses-API shape — {"type":"custom","name":…,"format":{…}} — instead of
+// Chat Completions' nested {"custom":{…}} wrapper, and references them the
+// same way in tool_choice. Use this for OpenAI-compatible gateways that
+// forward the tools array verbatim into a Responses API request (OpenRouter
+// does; verified live 2026-08-15 — the nested shape is rejected upstream with
+// "Missing required parameter: 'tools[0].name'" while the flat shape gets
+// grammar-constrained decoding).
+func (m *ChatCompletionsAPI) WithFlatCustomTools() *ChatCompletionsAPI {
+	m.flatCustomTools = true
 	return m
 }
 
@@ -226,7 +242,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 
 	if toolbox != nil {
 		// Build tools first.
-		apiTools, err := toolsFromToolbox(toolbox)
+		apiTools, err := toolsFromToolbox(toolbox, m.flatCustomTools)
 		if err != nil {
 			return nil, err
 		}
@@ -241,37 +257,14 @@ func (m *ChatCompletionsAPI) BuildPayload(
 			if len(choice.AllowedTools) == 0 {
 				payload["tool_choice"] = "none"
 			} else {
-				// Validate that at least one allowed tool exists in apiTools
-				exists := false
-				for _, n := range choice.AllowedTools {
-					for _, t := range apiTools {
-						name := ""
-						if t.Function != nil {
-							name = t.Function.Name
-						}
-						if t.Custom != nil {
-							name = t.Custom.Name
-						}
-						if name == n {
-							exists = true
-							break
-						}
-					}
-					if exists {
-						break
-					}
-				}
-				if !exists {
+				if !anyChatToolExists(choice.AllowedTools, apiTools) {
 					return nil, fmt.Errorf("openai chat: no allowed tools found in toolbox")
 				}
-				// Build allowed_tools object
-				allowed := make([]ChatAllowedTool, 0, len(choice.AllowedTools))
-				for _, n := range choice.AllowedTools {
-					// Prefer function type; fall back to custom if applicable
-					// We don’t try to disambiguate; include function entry, which the model resolves
-					allowed = append(allowed, ChatAllowedTool{Type: "function", Function: &ChatAllowedToolFunc{Name: n}})
+				payload["tool_choice"] = ChatAllowedToolsChoice{
+					Type:  "allowed_tools",
+					Mode:  "auto",
+					Tools: m.chatAllowedToolEntries(choice.AllowedTools, apiTools),
 				}
-				payload["tool_choice"] = ChatAllowedToolsChoice{Type: "allowed_tools", Mode: "auto", Tools: allowed}
 			}
 		case tools.ChoiceRequireOneOf:
 			switch len(choice.AllowedTools) {
@@ -280,46 +273,24 @@ func (m *ChatCompletionsAPI) BuildPayload(
 			case 1:
 				// Force the specific tool by name; validate it exists
 				name := choice.AllowedTools[0]
-				exists := false
-				for _, t := range apiTools {
-					if (t.Function != nil && t.Function.Name == name) || (t.Custom != nil && t.Custom.Name == name) {
-						exists = true
-						break
-					}
-				}
-				if !exists {
+				if !anyChatToolExists([]string{name}, apiTools) {
 					return nil, fmt.Errorf("openai chat: required tool %q not found in toolbox", name)
 				}
-				payload["tool_choice"] = ChatToolChoice{Type: "function", Function: &ChatToolChoiceFunc{Name: name}}
+				if m.flatCustomTools && chatToolIsCustom(name, apiTools) {
+					payload["tool_choice"] = ChatToolChoice{Type: "custom", Name: name}
+				} else {
+					payload["tool_choice"] = ChatToolChoice{Type: "function", Function: &ChatToolChoiceFunc{Name: name}}
+				}
 			default:
 				// Multiple allowed: use allowed_tools with mode:required
-				exists := false
-				for _, n := range choice.AllowedTools {
-					for _, t := range apiTools {
-						name := ""
-						if t.Function != nil {
-							name = t.Function.Name
-						}
-						if t.Custom != nil {
-							name = t.Custom.Name
-						}
-						if name == n {
-							exists = true
-							break
-						}
-					}
-					if exists {
-						break
-					}
-				}
-				if !exists {
+				if !anyChatToolExists(choice.AllowedTools, apiTools) {
 					return nil, fmt.Errorf("openai chat: none of the required tools are present in toolbox")
 				}
-				allowed := make([]ChatAllowedTool, 0, len(choice.AllowedTools))
-				for _, n := range choice.AllowedTools {
-					allowed = append(allowed, ChatAllowedTool{Type: "function", Function: &ChatAllowedToolFunc{Name: n}})
+				payload["tool_choice"] = ChatAllowedToolsChoice{
+					Type:  "allowed_tools",
+					Mode:  "required",
+					Tools: m.chatAllowedToolEntries(choice.AllowedTools, apiTools),
 				}
-				payload["tool_choice"] = ChatAllowedToolsChoice{Type: "allowed_tools", Mode: "required", Tools: allowed}
 			}
 		default:
 			payload["tool_choice"] = "auto"
@@ -1053,7 +1024,77 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 	}
 }
 
-func toolsFromToolbox(toolbox *tools.Toolbox) ([]Tool, error) {
+// anyChatToolExists reports whether at least one of the named tools is
+// declared in apiTools, matching function, nested custom, and flat custom
+// declarations.
+func anyChatToolExists(names []string, apiTools []Tool) bool {
+	for _, n := range names {
+		for _, t := range apiTools {
+			if (t.Function != nil && t.Function.Name == n) ||
+				(t.Custom != nil && t.Custom.Name == n) ||
+				t.Name == n {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// chatToolIsCustom reports whether the named tool is declared as a custom
+// tool in apiTools, in either the nested or the flat form.
+func chatToolIsCustom(name string, apiTools []Tool) bool {
+	for _, t := range apiTools {
+		if t.Type != "custom" {
+			continue
+		}
+		if (t.Custom != nil && t.Custom.Name == name) || t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// chatAllowedToolEntries builds allowed_tools entries, keeping each named
+// tool's declared type. Custom tools are referenced in the flat
+// Responses-style form when flatCustomTools is set (matching how they were
+// declared); everything else keeps the function form, which also preserves
+// the previous behavior for unknown names.
+func (m *ChatCompletionsAPI) chatAllowedToolEntries(names []string, apiTools []Tool) []ChatAllowedTool {
+	allowed := make([]ChatAllowedTool, 0, len(names))
+	for _, n := range names {
+		if m.flatCustomTools && chatToolIsCustom(n, apiTools) {
+			allowed = append(allowed, ChatAllowedTool{Type: "custom", Name: n})
+		} else {
+			allowed = append(allowed, ChatAllowedTool{Type: "function", Function: &ChatAllowedToolFunc{Name: n}})
+		}
+	}
+	return allowed
+}
+
+func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools bool) ([]Tool, error) {
+	// customTool builds a custom tool declaration. The flat form mirrors the
+	// Responses API ({"type":"custom","name":…,"format":{"type":"grammar",
+	// "syntax":…,"definition":…}}) for endpoints that forward the tools array
+	// there; the nested form is Chat Completions' own wrapper.
+	customTool := func(t tools.Tool, format map[string]any) Tool {
+		if flatCustomTools {
+			if format["type"] == "grammar" {
+				grammar := format["grammar"].(map[string]any)
+				format = map[string]any{
+					"type":       "grammar",
+					"syntax":     grammar["syntax"],
+					"definition": grammar["definition"],
+				}
+			}
+			return Tool{Type: "custom", Name: t.FuncName(), Description: t.Description(), Format: format}
+		}
+		return Tool{Type: "custom", Custom: &CustomToolSchema{
+			Name:        t.FuncName(),
+			Description: t.Description(),
+			Format:      format,
+		}}
+	}
+
 	apiTools := []Tool{}
 	for _, t := range toolbox.All() {
 		switch g := t.Grammar().(type) {
@@ -1062,35 +1103,23 @@ func toolsFromToolbox(toolbox *tools.Toolbox) ([]Tool, error) {
 				apiTools = append(apiTools, Tool{Type: "function", Function: schema})
 			}
 		case tools.TextGrammar:
-			apiTools = append(apiTools, Tool{Type: "custom", Custom: &CustomToolSchema{
-				Name:        t.FuncName(),
-				Description: t.Description(),
-				Format:      map[string]any{"type": "text"},
-			}})
+			apiTools = append(apiTools, customTool(t, map[string]any{"type": "text"}))
 		case tools.LarkGrammar:
-			apiTools = append(apiTools, Tool{Type: "custom", Custom: &CustomToolSchema{
-				Name:        t.FuncName(),
-				Description: t.Description(),
-				Format: map[string]any{
-					"type": "grammar",
-					"grammar": map[string]any{
-						"definition": g.Definition,
-						"syntax":     "lark",
-					},
+			apiTools = append(apiTools, customTool(t, map[string]any{
+				"type": "grammar",
+				"grammar": map[string]any{
+					"definition": g.Definition,
+					"syntax":     "lark",
 				},
-			}})
+			}))
 		case tools.RegexGrammar:
-			apiTools = append(apiTools, Tool{Type: "custom", Custom: &CustomToolSchema{
-				Name:        t.FuncName(),
-				Description: t.Description(),
-				Format: map[string]any{
-					"type": "grammar",
-					"grammar": map[string]any{
-						"definition": g.Definition,
-						"syntax":     "regex",
-					},
+			apiTools = append(apiTools, customTool(t, map[string]any{
+				"type": "grammar",
+				"grammar": map[string]any{
+					"definition": g.Definition,
+					"syntax":     "regex",
 				},
-			}})
+			}))
 		default:
 			return nil, fmt.Errorf("openai chat: unsupported tool grammar type %T", g)
 		}
@@ -1099,7 +1128,7 @@ func toolsFromToolbox(toolbox *tools.Toolbox) ([]Tool, error) {
 }
 
 func Tools(toolbox *tools.Toolbox) []Tool {
-	apiTools, err := toolsFromToolbox(toolbox)
+	apiTools, err := toolsFromToolbox(toolbox, false)
 	if err != nil {
 		panic(err)
 	}

--- a/openai/chatcompletions_flat_custom_test.go
+++ b/openai/chatcompletions_flat_custom_test.go
@@ -1,0 +1,124 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/flitsinc/go-llms/tools"
+)
+
+func flatModeToolbox() *tools.Toolbox {
+	patch := tools.FuncGrammar(tools.Lark("start: \"x\""), "apply_patch", "Apply a patch.", "apply_patch",
+		func(r tools.Runner, input string) tools.Result { return tools.SuccessFromString("ok") })
+	read := tools.Func("Read", "Read a file.", "read_file",
+		func(r tools.Runner, params struct {
+			Path string `json:"path"`
+		}) tools.Result {
+			return tools.SuccessFromString("ok")
+		})
+	return tools.Box(patch, read)
+}
+
+// marshalToolsArray round-trips the tools array through JSON, which is what
+// the wire sees; the flat/nested distinction only matters in that form.
+func marshalToolsArray(t *testing.T, apiTools []Tool) []map[string]any {
+	t.Helper()
+	data, err := json.Marshal(apiTools)
+	if err != nil {
+		t.Fatalf("marshal tools: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal tools: %v", err)
+	}
+	return decoded
+}
+
+func TestToolsFromToolbox_FlatCustomTools(t *testing.T) {
+	apiTools, err := toolsFromToolbox(flatModeToolbox(), true)
+	if err != nil {
+		t.Fatalf("toolsFromToolbox: %v", err)
+	}
+	byName := map[string]map[string]any{}
+	for _, entry := range marshalToolsArray(t, apiTools) {
+		if name, ok := entry["name"].(string); ok {
+			byName[name] = entry
+		} else if fn, ok := entry["function"].(map[string]any); ok {
+			byName[fn["name"].(string)] = entry
+		}
+	}
+
+	patch := byName["apply_patch"]
+	if patch == nil || patch["type"] != "custom" {
+		t.Fatalf("expected flat custom apply_patch, got %#v", byName)
+	}
+	if _, nested := patch["custom"]; nested {
+		t.Fatalf("flat mode must not emit the nested custom wrapper (OpenRouter's Responses upstream rejects it): %#v", patch)
+	}
+	format, ok := patch["format"].(map[string]any)
+	if !ok || format["type"] != "grammar" || format["syntax"] != "lark" || format["definition"] != "start: \"x\"" {
+		t.Fatalf("flat custom tool must carry the flat Responses-style format, got %#v", patch["format"])
+	}
+	if byName["read_file"]["type"] != "function" {
+		t.Fatalf("JSON tools must stay function-typed, got %#v", byName["read_file"])
+	}
+}
+
+func TestToolsFromToolbox_NestedCustomToolsUnchanged(t *testing.T) {
+	apiTools, err := toolsFromToolbox(flatModeToolbox(), false)
+	if err != nil {
+		t.Fatalf("toolsFromToolbox: %v", err)
+	}
+	for _, entry := range marshalToolsArray(t, apiTools) {
+		if entry["type"] != "custom" {
+			continue
+		}
+		custom, ok := entry["custom"].(map[string]any)
+		if !ok {
+			t.Fatalf("nested mode must keep the custom wrapper, got %#v", entry)
+		}
+		format := custom["format"].(map[string]any)
+		grammar, ok := format["grammar"].(map[string]any)
+		if !ok || grammar["syntax"] != "lark" {
+			t.Fatalf("nested mode must keep the nested grammar format, got %#v", format)
+		}
+		return
+	}
+	t.Fatal("no custom tool found in nested mode")
+}
+
+func TestChatToolChoice_FlatCustomForceAndAllowList(t *testing.T) {
+	m := New("key", "gpt-5.6-luna").WithFlatCustomTools()
+	toolbox := flatModeToolbox()
+
+	toolbox.Choice = tools.Choice{Mode: tools.ChoiceRequireOneOf, AllowedTools: []string{"apply_patch"}}
+	payload, err := m.BuildPayload(nil, nil, toolbox, nil)
+	if err != nil {
+		t.Fatalf("BuildPayload: %v", err)
+	}
+	forced, ok := payload["tool_choice"].(ChatToolChoice)
+	if !ok || forced.Type != "custom" || forced.Name != "apply_patch" || forced.Function != nil {
+		t.Fatalf("forcing a flat custom tool must use {type:custom,name}, got %#v", payload["tool_choice"])
+	}
+
+	toolbox.Choice = tools.Choice{Mode: tools.ChoiceAllowOnly, AllowedTools: []string{"apply_patch", "read_file"}}
+	payload, err = m.BuildPayload(nil, nil, toolbox, nil)
+	if err != nil {
+		t.Fatalf("BuildPayload: %v", err)
+	}
+	allowed, ok := payload["tool_choice"].(ChatAllowedToolsChoice)
+	if !ok {
+		t.Fatalf("expected allowed_tools choice, got %#v", payload["tool_choice"])
+	}
+	types := map[string]string{}
+	for _, entry := range allowed.Tools {
+		if entry.Name != "" {
+			types[entry.Name] = entry.Type
+		} else if entry.Function != nil {
+			types[entry.Function.Name] = entry.Type
+		}
+	}
+	if types["apply_patch"] != "custom" || types["read_file"] != "function" {
+		t.Fatalf("allow-list must keep declared types in flat mode, got %#v", types)
+	}
+}

--- a/openai/chatcompletions_flat_custom_test.go
+++ b/openai/chatcompletions_flat_custom_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/flitsinc/go-llms/llms"
 	"github.com/flitsinc/go-llms/tools"
 )
 
@@ -85,6 +86,32 @@ func TestToolsFromToolbox_NestedCustomToolsUnchanged(t *testing.T) {
 		return
 	}
 	t.Fatal("no custom tool found in nested mode")
+}
+
+func TestFlatCustomReplayKeepsRawFunctionArguments(t *testing.T) {
+	// On flat-custom-tools endpoints (OpenRouter), grammar-tool calls come
+	// back function-shaped with raw non-JSON arguments; replaying them must
+	// not sanitize the input away.
+	rawPatch := "*** Begin Patch\n*** Add File: hello.txt\n+hi\n*** End Patch\n"
+	msg := llms.Message{
+		Role: "assistant",
+		ToolCalls: []llms.ToolCall{{
+			ID:        "call_1",
+			Name:      "apply_patch",
+			Arguments: json.RawMessage(rawPatch),
+			Metadata:  map[string]string{"openai:item_type": "function"},
+		}},
+	}
+
+	flat := MessagesFromLLMWithOptions(msg, chatMessageEncodingOptions{flatCustomTools: true})
+	if got := flat[0].ToolCalls[0].Function.Arguments; got != rawPatch {
+		t.Fatalf("flat mode must replay raw arguments verbatim, got %q", got)
+	}
+
+	nested := MessagesFromLLMWithOptions(msg, chatMessageEncodingOptions{})
+	if got := nested[0].ToolCalls[0].Function.Arguments; got != "{}" {
+		t.Fatalf("non-flat mode must keep sanitizing invalid JSON, got %q", got)
+	}
 }
 
 func TestChatToolChoice_FlatCustomForceAndAllowList(t *testing.T) {

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -59,6 +59,12 @@ type ContentList []ContentPart
 type chatMessageEncodingOptions struct {
 	cacheControlPromptHints  bool
 	assistantReasoningReplay bool
+	// flatCustomTools mirrors ChatCompletionsAPI.flatCustomTools: the
+	// endpoint forwards requests to the Responses API upstream, where
+	// grammar-tool calls surface as function-shaped calls whose arguments
+	// are the raw (non-JSON) tool input. Replay must pass those arguments
+	// through verbatim; sanitizing them to "{}" would discard the input.
+	flatCustomTools bool
 }
 
 // ConvertContent converts content.Content to a ContentList for the OpenAI API.
@@ -331,7 +337,11 @@ func messagesFromLLMWithOptions(m llms.Message, opts chatMessageEncodingOptions)
 				}
 			default:
 				args := string(tc.Arguments)
-				if !json.Valid([]byte(args)) {
+				// Grammar-tool calls on flat-custom-tools endpoints carry raw
+				// text arguments in function-shaped calls; keep them verbatim
+				// (the upstream accepts them — it produced them). Elsewhere,
+				// invalid JSON is sanitized as before.
+				if !json.Valid([]byte(args)) && !opts.flatCustomTools {
 					args = "{}"
 				}
 				msg.ToolCalls[i] = toolCall{

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -161,7 +161,7 @@ func (m *ResponsesAPI) Generate(
 			Role:    "system",
 			Content: systemPrompt,
 		}
-		systemInputs, err := convertMessageToInput(systemMsg)
+		systemInputs, err := convertMessageToInput(systemMsg, nil)
 		if err != nil {
 			return newResponsesStreamError(fmt.Errorf("responses: failed to convert system message: %w", err))
 		}
@@ -169,8 +169,9 @@ func (m *ResponsesAPI) Generate(
 	}
 
 	// Convert messages to input items
+	customCallIDs := customToolCallIDs(messages)
 	for _, msg := range messages {
-		msgInputs, err := convertMessageToInput(msg)
+		msgInputs, err := convertMessageToInput(msg, customCallIDs)
 		if err != nil {
 			return newResponsesStreamError(fmt.Errorf("responses: failed to convert message role=%s: %w", msg.Role, err))
 		}
@@ -381,8 +382,31 @@ func (s *ResponsesStream) Iter() func(yield func(llms.StreamStatus) bool) {
 	}
 }
 
-// convertMessageToInput converts an llms.Message to ResponseInput items
-func convertMessageToInput(msg llms.Message) ([]ResponseInput, error) {
+// customToolCallIDs collects the call IDs of assistant tool calls made
+// through the custom (grammar/text) tool protocol, so their results replay as
+// custom_tool_call_output items. Conversion callers build this once per
+// message list and pass it to convertMessageToInput, because a tool-result
+// message alone cannot tell which protocol its call used.
+func customToolCallIDs(messages []llms.Message) map[string]bool {
+	var ids map[string]bool
+	for _, msg := range messages {
+		for _, tc := range msg.ToolCalls {
+			if tc.Metadata["openai:item_type"] == "custom_tool_call" {
+				if ids == nil {
+					ids = map[string]bool{}
+				}
+				ids[tc.ID] = true
+			}
+		}
+	}
+	return ids
+}
+
+// convertMessageToInput converts an llms.Message to ResponseInput items.
+// customCallIDs marks tool-call IDs whose calls were custom_tool_call items,
+// so their results serialize as custom_tool_call_output; nil is valid when
+// the conversation cannot contain custom tool calls.
+func convertMessageToInput(msg llms.Message, customCallIDs map[string]bool) ([]ResponseInput, error) {
 	var items []ResponseInput
 
 	switch msg.Role {
@@ -509,11 +533,19 @@ func convertMessageToInput(msg llms.Message) ([]ResponseInput, error) {
 			}
 		}
 
-		items = append(items, FunctionCallOutput{
-			Type:   "function_call_output",
-			CallID: msg.ToolCallID,
-			Output: outputStr,
-		})
+		if customCallIDs[msg.ToolCallID] {
+			items = append(items, CustomToolCallOutput{
+				Type:   "custom_tool_call_output",
+				CallID: msg.ToolCallID,
+				Output: outputStr,
+			})
+		} else {
+			items = append(items, FunctionCallOutput{
+				Type:   "function_call_output",
+				CallID: msg.ToolCallID,
+				Output: outputStr,
+			})
+		}
 		return items, nil
 	}
 

--- a/openai/responses_custom_output_test.go
+++ b/openai/responses_custom_output_test.go
@@ -1,0 +1,98 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/flitsinc/go-llms/tools"
+)
+
+func TestConvertMessageToInput_CustomToolCallResultUsesCustomOutput(t *testing.T) {
+	messages := []llms.Message{
+		{
+			Role: "assistant",
+			ToolCalls: []llms.ToolCall{
+				{
+					ID:        "call_custom",
+					Name:      "apply_patch",
+					Arguments: json.RawMessage("*** Begin Patch\n*** End Patch"),
+					Metadata:  map[string]string{"openai:item_type": "custom_tool_call", "openai:item_id": "item_1"},
+				},
+				{
+					ID:        "call_fn",
+					Name:      "read_file",
+					Arguments: json.RawMessage(`{"path":"a"}`),
+					Metadata:  map[string]string{"openai:item_type": "function_call", "openai:item_id": "item_2"},
+				},
+			},
+		},
+		{Role: "tool", ToolCallID: "call_custom", Content: content.FromText("ok")},
+		{Role: "tool", ToolCallID: "call_fn", Content: content.FromText("data")},
+	}
+
+	customCallIDs := customToolCallIDs(messages)
+	if len(customCallIDs) != 1 || !customCallIDs["call_custom"] {
+		t.Fatalf("expected only call_custom to be collected, got %#v", customCallIDs)
+	}
+
+	items, err := convertMessageToInput(messages[1], customCallIDs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d (%#v)", len(items), items)
+	}
+	customOut, ok := items[0].(CustomToolCallOutput)
+	if !ok {
+		t.Fatalf("a custom tool call's result must be a custom_tool_call_output (function_call_output is rejected by the API), got %#v", items[0])
+	}
+	if customOut.Type != "custom_tool_call_output" || customOut.CallID != "call_custom" || customOut.Output != "ok" {
+		t.Fatalf("unexpected custom output: %#v", customOut)
+	}
+
+	items, err = convertMessageToInput(messages[2], customCallIDs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := items[0].(FunctionCallOutput); !ok {
+		t.Fatalf("a function call's result must stay a function_call_output, got %#v", items[0])
+	}
+}
+
+func TestBuildToolChoice_CustomToolsKeepTheirDeclaredType(t *testing.T) {
+	toolsArr := []any{
+		map[string]any{"type": "custom", "name": "apply_patch", "format": map[string]any{"type": "grammar"}},
+		FunctionTool{Type: "function", Name: "read_file"},
+	}
+
+	forced, err := buildToolChoice(tools.Choice{Mode: tools.ChoiceRequireOneOf, AllowedTools: []string{"apply_patch"}}, toolsArr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	forcedMap, ok := forced.(map[string]any)
+	if !ok || forcedMap["type"] != "custom" || forcedMap["name"] != "apply_patch" {
+		t.Fatalf("forcing a custom tool must reference it as type custom, got %#v", forced)
+	}
+
+	allowed, err := buildToolChoice(tools.Choice{Mode: tools.ChoiceAllowOnly, AllowedTools: []string{"apply_patch", "read_file"}}, toolsArr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	allowedChoice, ok := allowed.(AllowedToolsToolChoice)
+	if !ok {
+		t.Fatalf("expected AllowedToolsToolChoice, got %#v", allowed)
+	}
+	types := map[string]string{}
+	for _, entry := range allowedChoice.Tools {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected entry %#v", entry)
+		}
+		types[m["name"].(string)] = m["type"].(string)
+	}
+	if types["apply_patch"] != "custom" || types["read_file"] != "function" {
+		t.Fatalf("allow-list must keep each tool's declared type, got %#v", types)
+	}
+}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -270,7 +270,7 @@ func TestConvertMessageToInput_AssistantReasoningAndOutput(t *testing.T) {
 		},
 	}
 
-	inputs, err := convertMessageToInput(msg)
+	inputs, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("convertMessageToInput returned error: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestConvertMessageToInput_ForeignToolCallOmitsResponsesItemID(t *testing.T)
 		},
 	}
 
-	items, err := convertMessageToInput(msg)
+	items, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestConvertMessageToInput_NativeResponsesToolCallMissingItemIDReturnsError(
 		},
 	}
 
-	_, err := convertMessageToInput(msg)
+	_, err := convertMessageToInput(msg, nil)
 	if err == nil {
 		t.Fatal("expected native Responses tool call without an item ID to fail")
 	}
@@ -413,7 +413,7 @@ func TestConvertMessageToInput_ChatCompletionsCustomToolCallReturnsError(t *test
 		},
 	}
 
-	if _, err := convertMessageToInput(msg); err == nil {
+	if _, err := convertMessageToInput(msg, nil); err == nil {
 		t.Fatal("expected Chat Completions custom tool replay to fail")
 	}
 }
@@ -436,7 +436,7 @@ func TestConvertMessageToInput_ReasoningPairedWithToolCall(t *testing.T) {
 			},
 		},
 	}
-	items, err := convertMessageToInput(msg)
+	items, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestConvertMessageToInput_PreservesReasoningOrderAcrossToolCalls(t *testing
 		},
 	}
 
-	items, err := convertMessageToInput(msg)
+	items, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestConvertMessageToInput_MultiMessageReasoningToolTextSequence(t *testing.
 
 	var sequence []ResponseInput
 	for i, msg := range messages {
-		items, err := convertMessageToInput(msg)
+		items, err := convertMessageToInput(msg, nil)
 		if err != nil {
 			t.Fatalf("message %d conversion failed: %v", i+1, err)
 		}
@@ -622,7 +622,7 @@ func TestConvertMessageToInput_PhasePreservedRoundTrip(t *testing.T) {
 		},
 	}
 
-	inputs, err := convertMessageToInput(msg)
+	inputs, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("convertMessageToInput returned error: %v", err)
 	}
@@ -651,7 +651,7 @@ func TestConvertMessageToInput_CommentaryPhase(t *testing.T) {
 		},
 	}
 
-	inputs, err := convertMessageToInput(msg)
+	inputs, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("convertMessageToInput returned error: %v", err)
 	}
@@ -677,7 +677,7 @@ func TestConvertMessageToInput_NoPhaseOmitted(t *testing.T) {
 		},
 	}
 
-	inputs, err := convertMessageToInput(msg)
+	inputs, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("convertMessageToInput returned error: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestConvertMessageToInput_PhaseWithReasoningAndToolCalls(t *testing.T) {
 		},
 	}
 
-	inputs, err := convertMessageToInput(msg)
+	inputs, err := convertMessageToInput(msg, nil)
 	if err != nil {
 		t.Fatalf("convertMessageToInput returned error: %v", err)
 	}
@@ -772,7 +772,7 @@ func TestConvertMessageToInput_ToolErrorResult(t *testing.T) {
 		ToolCallID: "tool_call_err",
 		Content:    content.FromText("connection refused"),
 		IsError:    true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -792,7 +792,7 @@ func TestConvertMessageToInput_ToolErrorResult(t *testing.T) {
 		ToolCallID: "tool_call_err2",
 		Content:    content.FromRawJSON(json.RawMessage(`{"error": "connection refused"}`)),
 		IsError:    true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/openai/responses_types.go
+++ b/openai/responses_types.go
@@ -208,6 +208,20 @@ type FunctionCallOutput struct {
 func (FunctionCallOutput) responseInput() {}
 func (FunctionCallOutput) responseItem()  {}
 
+// CustomToolCallOutput implements ResponseInput for the result of a custom
+// (grammar/text) tool call. The Responses API requires this item type when
+// the call was a custom_tool_call; a function_call_output paired with a
+// custom call is rejected.
+type CustomToolCallOutput struct {
+	Type   string `json:"type"` // "custom_tool_call_output"
+	ID     string `json:"id,omitempty"`
+	CallID string `json:"call_id"`
+	Output string `json:"output"`
+}
+
+func (CustomToolCallOutput) responseInput() {}
+func (CustomToolCallOutput) responseItem()  {}
+
 // Reasoning implements ResponseItem for reasoning
 type Reasoning struct {
 	Type             string             `json:"type"` // "reasoning"

--- a/openai/types.go
+++ b/openai/types.go
@@ -53,6 +53,13 @@ type Tool struct {
 	Type     string                `json:"type"`
 	Function *tools.FunctionSchema `json:"function,omitempty"`
 	Custom   *CustomToolSchema     `json:"custom,omitempty"`
+
+	// Flat Responses-style custom tool declaration, used instead of Custom
+	// when the endpoint forwards the tools array to the Responses API (see
+	// WithFlatCustomTools). Empty for nested declarations.
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Format      map[string]any `json:"format,omitempty"`
 }
 
 type CustomToolSchema struct {
@@ -84,6 +91,9 @@ type ChatAllowedTool struct {
 	Type     string                 `json:"type"` // "function" | "custom"
 	Function *ChatAllowedToolFunc   `json:"function,omitempty"`
 	Custom   *ChatAllowedToolCustom `json:"custom,omitempty"`
+	// Name is the flat Responses-style reference used for custom tools when
+	// the endpoint forwards tool_choice to the Responses API.
+	Name string `json:"name,omitempty"`
 }
 
 type ChatAllowedToolFunc struct {

--- a/openai/websocket.go
+++ b/openai/websocket.go
@@ -325,13 +325,14 @@ func (m *WebSocketResponsesAPI) Generate(
 	// Determine if we can use incremental chaining.
 	var input []ResponseInput
 	var previousResponseID string
+	customCallIDs := customToolCallIDs(messages)
 
 	if m.lastResponseID != "" && m.lastMessageCount > 0 &&
 		len(messages) > m.lastMessageCount &&
 		messages[m.lastMessageCount].Role == "assistant" {
 		// Incremental: only send new messages after the last response.
 		for _, msg := range messages[m.lastMessageCount+1:] {
-			msgInputs, err := convertMessageToInput(msg)
+			msgInputs, err := convertMessageToInput(msg, customCallIDs)
 			if err != nil {
 				return newWebSocketStreamError(fmt.Errorf("websocket: failed to convert message role=%s: %w", msg.Role, err))
 			}
@@ -341,7 +342,7 @@ func (m *WebSocketResponsesAPI) Generate(
 	} else if m.lastResponseID != "" && m.lastMessageCount == 0 {
 		// Warmup case: send full messages but chain off the warmup response.
 		for _, msg := range messages {
-			msgInputs, err := convertMessageToInput(msg)
+			msgInputs, err := convertMessageToInput(msg, customCallIDs)
 			if err != nil {
 				return newWebSocketStreamError(fmt.Errorf("websocket: failed to convert message role=%s: %w", msg.Role, err))
 			}
@@ -351,7 +352,7 @@ func (m *WebSocketResponsesAPI) Generate(
 	} else {
 		// Full payload: convert all messages.
 		for _, msg := range messages {
-			msgInputs, err := convertMessageToInput(msg)
+			msgInputs, err := convertMessageToInput(msg, customCallIDs)
 			if err != nil {
 				return newWebSocketStreamError(fmt.Errorf("websocket: failed to convert message role=%s: %w", msg.Role, err))
 			}
@@ -365,7 +366,7 @@ func (m *WebSocketResponsesAPI) Generate(
 		instructions = text
 	} else {
 		systemMsg := llms.Message{Role: "system", Content: systemPrompt}
-		systemInputs, err := convertMessageToInput(systemMsg)
+		systemInputs, err := convertMessageToInput(systemMsg, nil)
 		if err != nil {
 			return newWebSocketStreamError(fmt.Errorf("websocket: failed to convert system message: %w", err))
 		}
@@ -396,7 +397,7 @@ func (m *WebSocketResponsesAPI) Generate(
 			// system prompt, without previous_response_id.
 			var fullInput []ResponseInput
 			for _, msg := range messages {
-				msgInputs, convErr := convertMessageToInput(msg)
+				msgInputs, convErr := convertMessageToInput(msg, customCallIDs)
 				if convErr != nil {
 					return newWebSocketStreamError(fmt.Errorf("websocket: reconnect convert: %w", convErr))
 				}
@@ -405,7 +406,7 @@ func (m *WebSocketResponsesAPI) Generate(
 			// Re-apply non-text system prompt if needed.
 			if instructions == "" {
 				systemMsg := llms.Message{Role: "system", Content: systemPrompt}
-				systemInputs, sysErr := convertMessageToInput(systemMsg)
+				systemInputs, sysErr := convertMessageToInput(systemMsg, nil)
 				if sysErr != nil {
 					return newWebSocketStreamError(fmt.Errorf("websocket: reconnect system: %w", sysErr))
 				}
@@ -559,7 +560,7 @@ func buildToolChoice(choice tools.Choice, toolsArr []any) (any, error) {
 		}
 		var entries []any
 		for _, n := range choice.AllowedTools {
-			entries = append(entries, map[string]any{"type": "function", "name": n})
+			entries = append(entries, map[string]any{"type": declaredToolType(n, toolsArr), "name": n})
 		}
 		return AllowedToolsToolChoice{Type: "allowed_tools", Mode: "auto", Tools: entries}, nil
 
@@ -572,14 +573,14 @@ func buildToolChoice(choice tools.Choice, toolsArr []any) (any, error) {
 			if !anyToolExists([]string{name}, toolsArr) {
 				return nil, fmt.Errorf("openai responses: required tool %q not found in toolbox", name)
 			}
-			return map[string]any{"type": "function", "name": name}, nil
+			return map[string]any{"type": declaredToolType(name, toolsArr), "name": name}, nil
 		default:
 			if !anyToolExists(choice.AllowedTools, toolsArr) {
 				return nil, fmt.Errorf("openai responses: none of the required tools are present in toolbox")
 			}
 			var entries []any
 			for _, n := range choice.AllowedTools {
-				entries = append(entries, map[string]any{"type": "function", "name": n})
+				entries = append(entries, map[string]any{"type": declaredToolType(n, toolsArr), "name": n})
 			}
 			return AllowedToolsToolChoice{Type: "allowed_tools", Mode: "required", Tools: entries}, nil
 		}
@@ -587,6 +588,29 @@ func buildToolChoice(choice tools.Choice, toolsArr []any) (any, error) {
 	default:
 		return "auto", nil
 	}
+}
+
+// declaredToolType resolves the wire type a named tool is declared with in
+// toolsArr, so a forced or allow-listed tool_choice references custom
+// (grammar/text) tools as {"type":"custom"} instead of mislabeling them as
+// functions, which the API rejects. Unknown names default to "function",
+// matching the previous behavior for hosted/special tools.
+func declaredToolType(name string, toolsArr []any) string {
+	for _, it := range toolsArr {
+		switch v := it.(type) {
+		case FunctionTool:
+			if v.Name == name {
+				return "function"
+			}
+		case map[string]any:
+			if n, ok := v["name"].(string); ok && n == name {
+				if typ, ok := v["type"].(string); ok && typ != "" {
+					return typ
+				}
+			}
+		}
+	}
+	return "function"
 }
 
 // anyToolExists checks whether at least one of the named tools exists in

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -11,11 +11,15 @@ type Reasoning struct {
 }
 
 // New returns a Chat Completions client configured for OpenRouter.
+// Custom (grammar/text) tools use the flat Responses-style declaration
+// because OpenRouter forwards the tools array into a Responses API request
+// upstream, where the nested Chat Completions wrapper is rejected.
 func New(apiKey, model string) *Provider {
 	return openai.New(apiKey, model).
 		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
 		WithCacheControlPromptHints().
-		WithAssistantReasoningReplay()
+		WithAssistantReasoningReplay().
+		WithFlatCustomTools()
 }
 
 // NewWithReasoning returns an OpenRouter-configured Chat Completions client


### PR DESCRIPTION
Custom (grammar/text) tool support had gaps that break the first conversation actually using one, plus an OpenRouter-specific declaration-shape requirement found by live probing. Found while wiring grammar-constrained tools into the builder API (flitsinc/builder#7904), whose review flagged the blocking one.

**Commit 1 — replay custom tool calls correctly (Responses API):**

- A custom tool call's result replayed as `function_call_output`; the Responses API requires `custom_tool_call_output` when the call was a `custom_tool_call`, so the turn after the tool ran was rejected. `convertMessageToInput` now takes the set of custom call IDs (collected once per message list by `customToolCallIDs`) and emits the matching output item type. Both the HTTP Responses path and the WebSocket path pass the set.
- `buildToolChoice` hardcoded `{"type":"function"}` for forced and allow-listed tools; entries now carry the tool's declared type from the tools array.

**Commit 2 — flat Responses-style custom tools for OpenRouter:**

OpenRouter forwards the Chat Completions tools array verbatim into an OpenAI Responses request upstream, so the nested CC custom-tool wrapper is rejected there (`Missing required parameter: 'tools[0].name'`). Live probes (2026-08-15) showed the flat Responses shape passes through and gets genuinely sampler-constrained decoding (a grammar pinning the filename overrode the prompted one), with the call streamed back as a function-shaped tool call carrying raw input.

- `WithFlatCustomTools()` opts a CC client into the flat shape for declarations and tool_choice references (forced/allow-listed custom tools become `{"type":"custom","name":…}`, probe-verified). `openrouter.New` enables it; direct CC keeps the nested shape.
- Tool-existence validation recognizes all three declaration forms via a shared helper.

Verified end-to-end with a live two-turn run of this client against openrouter.ai (`openai/gpt-5.6-luna`): flat declaration → constrained raw input streamed into the tool fn → history replay accepted on turn 2.

Builder pins this branch via go.mod pseudo-version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wire format and message replay for custom tools across Chat Completions, Responses, WebSocket, and OpenRouter defaults; mistakes could break tool calling on those providers, but behavior is heavily tested and scoped to custom-tool paths.
> 
> **Overview**
> Fixes **grammar/text custom tools** so multi-turn conversations work on Responses-style upstreams (including OpenRouter) and replay does not drop raw tool input.
> 
> **Responses API replay:** Tool results from `custom_tool_call` assistant turns now serialize as `custom_tool_call_output` instead of `function_call_output`. `tool_choice` for forced and allow-listed tools uses each tool’s **declared** type (`custom` vs `function`) via `declaredToolType` / shared helpers.
> 
> **Chat Completions flat mode:** Adds `WithFlatCustomTools()` so custom tools are declared as flat `{"type":"custom","name",…,"format"}` (not nested `custom` wrapper), with matching `tool_choice` references. **OpenRouter** enables this by default. In flat mode, replay keeps **raw non-JSON** function-shaped tool arguments verbatim instead of sanitizing them to `{}`.
> 
> Adds unit tests for flat/nested declarations, replay, and Responses conversion, plus a live OpenRouter integration test for the full two-turn grammar-tool flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8118510dbbfd7e8025189c38006e1682422f5b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->