### PR TITLE
Fix Gemini tool calling: drop enums offering "" and stop discarding valid ones

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -12,74 +12,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/metalim/jsonmap"
 	"golang.org/x/oauth2"
 
 	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/internal/geminischema"
 	"github.com/flitsinc/go-llms/llms"
 	"github.com/flitsinc/go-llms/tools"
 )
-
-// sanitizeSchemaForGemini recursively removes unsupported JSON Schema properties
-// to make schemas compatible with Google's Gemini API. This includes:
-//   - Setting AdditionalProperties to nil
-//   - Stripping unsupported keywords like exclusiveMinimum, const, pattern, etc.
-//     by round-tripping through tools.ValueSchema which only has supported fields.
-func sanitizeSchemaForGemini(schema *tools.ValueSchema) {
-	schema.AdditionalProperties = nil
-
-	if schema.Items != nil {
-		sanitizeSchemaForGemini(schema.Items)
-	}
-
-	if schema.Properties != nil {
-		for _, k := range schema.Properties.Keys() {
-			raw, ok := schema.Properties.Get(k)
-			if !ok {
-				continue
-			}
-
-			var v tools.ValueSchema
-			switch val := raw.(type) {
-			case tools.ValueSchema:
-				v = val
-			case *jsonmap.Map:
-				// Property is a nested map from jsonmap - marshal to JSON then
-				// unmarshal into ValueSchema to strip unsupported fields.
-				data, err := json.Marshal(val)
-				if err != nil {
-					continue
-				}
-				if err := json.Unmarshal(data, &v); err != nil {
-					continue
-				}
-			case map[string]any:
-				// Property is a generic map - marshal to JSON then unmarshal
-				// into ValueSchema to strip unsupported fields.
-				data, err := json.Marshal(val)
-				if err != nil {
-					continue
-				}
-				if err := json.Unmarshal(data, &v); err != nil {
-					continue
-				}
-			case json.RawMessage:
-				if err := json.Unmarshal(val, &v); err != nil {
-					continue
-				}
-			default:
-				continue
-			}
-
-			sanitizeSchemaForGemini(&v)
-			schema.Properties.Set(k, v)
-		}
-	}
-
-	for i := range schema.AnyOf {
-		sanitizeSchemaForGemini(&schema.AnyOf[i])
-	}
-}
 
 type Model struct {
 	tokenSource      oauth2.TokenSource
@@ -400,9 +339,7 @@ func (m *Model) Generate(
 			// Google supports only function-style tools; JSON grammar is fine.
 			switch g := tool.Grammar().(type) {
 			case tools.JSONGrammar:
-				schema := *g.Schema()
-				sanitizeSchemaForGemini(&schema.Parameters)
-				declarations[i] = schema
+				declarations[i] = geminischema.SanitizeFunction(*g.Schema())
 			default:
 				return &Stream{err: fmt.Errorf("google: unsupported tool grammar type %T", g)}
 			}

--- a/internal/geminischema/geminischema.go
+++ b/internal/geminischema/geminischema.go
@@ -1,0 +1,114 @@
+// Package geminischema narrows JSON Schema tool declarations to the subset
+// Google's function-calling API accepts.
+//
+// Gemini rejects a request outright (HTTP 400) when a function declaration
+// carries JSON Schema keywords it does not implement — most notably
+// "additionalProperties", but also "const", "pattern", "exclusiveMinimum" and
+// the rest of the validation vocabulary. Callers that target OpenAI's strict
+// mode emit exactly those keywords, so their toolbox is unusable against
+// Gemini until it is narrowed here.
+//
+// This lives in its own package because Gemini is reachable by two different
+// transports: the native API in the google package, and OpenAI-compatible
+// gateways such as OpenRouter in the openai package. Both must narrow schemas
+// identically, and a single implementation is the only way that stays true.
+package geminischema
+
+import (
+	"encoding/json"
+
+	"github.com/metalim/jsonmap"
+
+	"github.com/flitsinc/go-llms/tools"
+)
+
+// SanitizeFunction returns a copy of schema whose parameters are safe to send
+// to Gemini. The input is never modified, so the caller's toolbox stays intact
+// for other providers sharing it.
+func SanitizeFunction(schema tools.FunctionSchema) tools.FunctionSchema {
+	schema.Parameters = SanitizeValue(schema.Parameters)
+	return schema
+}
+
+// SanitizeValue returns a deep copy of schema with the keywords Gemini rejects
+// removed:
+//
+//   - "additionalProperties" is dropped at every level.
+//   - Every other keyword outside tools.ValueSchema is dropped by round-tripping
+//     nested property schemas through ValueSchema, which only has fields Gemini
+//     understands.
+func SanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
+	schema.AdditionalProperties = nil
+
+	if schema.Items != nil {
+		items := SanitizeValue(*schema.Items)
+		schema.Items = &items
+	}
+
+	if schema.Required != nil {
+		schema.Required = append([]string(nil), schema.Required...)
+	}
+
+	if schema.AnyOf != nil {
+		anyOf := make([]tools.ValueSchema, len(schema.AnyOf))
+		for i, alternative := range schema.AnyOf {
+			anyOf[i] = SanitizeValue(alternative)
+		}
+		schema.AnyOf = anyOf
+	}
+
+	if schema.Properties != nil {
+		properties := jsonmap.New()
+		for _, key := range schema.Properties.Keys() {
+			raw, ok := schema.Properties.Get(key)
+			if !ok {
+				continue
+			}
+			value, ok := asValueSchema(raw)
+			if !ok {
+				// Not schema-shaped, so there is nothing to narrow and no safe
+				// way to rewrite it. Carry it over untouched rather than drop a
+				// property the model is expected to fill.
+				properties.Set(key, raw)
+				continue
+			}
+			properties.Set(key, SanitizeValue(value))
+		}
+		schema.Properties = properties
+	}
+
+	return schema
+}
+
+// asValueSchema reinterprets one property entry as a ValueSchema. Properties
+// arrive as decoded JSON rather than typed values whenever the schema came off
+// the wire, so the concrete type varies by caller.
+func asValueSchema(raw any) (tools.ValueSchema, bool) {
+	switch value := raw.(type) {
+	case tools.ValueSchema:
+		return value, true
+	case *tools.ValueSchema:
+		if value == nil {
+			return tools.ValueSchema{}, false
+		}
+		return *value, true
+	case json.RawMessage:
+		var schema tools.ValueSchema
+		if json.Unmarshal(value, &schema) != nil {
+			return tools.ValueSchema{}, false
+		}
+		return schema, true
+	case *jsonmap.Map, map[string]any:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return tools.ValueSchema{}, false
+		}
+		var schema tools.ValueSchema
+		if json.Unmarshal(data, &schema) != nil {
+			return tools.ValueSchema{}, false
+		}
+		return schema, true
+	default:
+		return tools.ValueSchema{}, false
+	}
+}

--- a/internal/geminischema/geminischema.go
+++ b/internal/geminischema/geminischema.go
@@ -26,6 +26,12 @@ import (
 // to Gemini:
 //
 //   - "additionalProperties" is dropped at every level.
+//   - An enum offering "" is dropped entirely. Google rejects the empty string
+//     as an enum value (verified live 2026-08-19: a declaration carrying one is
+//     answered with a 400 and the request never reaches the model), and callers
+//     use "" as the "no filter" choice, so removing just that member would take
+//     away the option rather than the error. Dropping the enum leaves a plain
+//     string, which still accepts every value the caller meant to offer.
 //   - Every other keyword outside tools.ValueSchema is dropped, because
 //     ValueSchema only has fields Gemini understands.
 //
@@ -38,6 +44,13 @@ func SanitizeFunction(schema tools.FunctionSchema) tools.FunctionSchema {
 
 func sanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
 	schema.AdditionalProperties = nil
+
+	for _, choice := range schema.Enum {
+		if choice == "" {
+			schema.Enum = nil
+			break
+		}
+	}
 
 	if schema.Items != nil {
 		items := sanitizeValue(*schema.Items)

--- a/internal/geminischema/geminischema.go
+++ b/internal/geminischema/geminischema.go
@@ -23,36 +23,31 @@ import (
 )
 
 // SanitizeFunction returns a copy of schema whose parameters are safe to send
-// to Gemini. The input is never modified, so the caller's toolbox stays intact
-// for other providers sharing it.
+// to Gemini:
+//
+//   - "additionalProperties" is dropped at every level.
+//   - Every other keyword outside tools.ValueSchema is dropped, because
+//     ValueSchema only has fields Gemini understands.
+//
+// The input is never modified, so a toolbox shared with other providers keeps
+// its full schema.
 func SanitizeFunction(schema tools.FunctionSchema) tools.FunctionSchema {
-	schema.Parameters = SanitizeValue(schema.Parameters)
+	schema.Parameters = sanitizeValue(schema.Parameters)
 	return schema
 }
 
-// SanitizeValue returns a deep copy of schema with the keywords Gemini rejects
-// removed:
-//
-//   - "additionalProperties" is dropped at every level.
-//   - Every other keyword outside tools.ValueSchema is dropped by round-tripping
-//     nested property schemas through ValueSchema, which only has fields Gemini
-//     understands.
-func SanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
+func sanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
 	schema.AdditionalProperties = nil
 
 	if schema.Items != nil {
-		items := SanitizeValue(*schema.Items)
+		items := sanitizeValue(*schema.Items)
 		schema.Items = &items
-	}
-
-	if schema.Required != nil {
-		schema.Required = append([]string(nil), schema.Required...)
 	}
 
 	if schema.AnyOf != nil {
 		anyOf := make([]tools.ValueSchema, len(schema.AnyOf))
 		for i, alternative := range schema.AnyOf {
-			anyOf[i] = SanitizeValue(alternative)
+			anyOf[i] = sanitizeValue(alternative)
 		}
 		schema.AnyOf = anyOf
 	}
@@ -67,12 +62,13 @@ func SanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
 			value, ok := asValueSchema(raw)
 			if !ok {
 				// Not schema-shaped, so there is nothing to narrow and no safe
-				// way to rewrite it. Carry it over untouched rather than drop a
-				// property the model is expected to fill.
+				// way to rewrite it. Carrying it over keeps a property the
+				// model needs, at the cost of Gemini still refusing it — which
+				// is what would happen anyway.
 				properties.Set(key, raw)
 				continue
 			}
-			properties.Set(key, SanitizeValue(value))
+			properties.Set(key, sanitizeValue(value))
 		}
 		schema.Properties = properties
 	}
@@ -80,35 +76,22 @@ func SanitizeValue(schema tools.ValueSchema) tools.ValueSchema {
 	return schema
 }
 
-// asValueSchema reinterprets one property entry as a ValueSchema. Properties
-// arrive as decoded JSON rather than typed values whenever the schema came off
-// the wire, so the concrete type varies by caller.
+// asValueSchema reinterprets one property entry as a ValueSchema.
+//
+// Properties are typed as `any` (jsonmap preserves declaration order but not
+// types), so the concrete type depends on how the schema was built: decoding
+// one off the wire yields *jsonmap.Map, while tools.Func builds ValueSchema
+// directly. Round-tripping through JSON handles every shape without a type
+// switch that would have to guess at the full set, and it is the same
+// marshalling the request itself performs a moment later.
 func asValueSchema(raw any) (tools.ValueSchema, bool) {
-	switch value := raw.(type) {
-	case tools.ValueSchema:
-		return value, true
-	case *tools.ValueSchema:
-		if value == nil {
-			return tools.ValueSchema{}, false
-		}
-		return *value, true
-	case json.RawMessage:
-		var schema tools.ValueSchema
-		if json.Unmarshal(value, &schema) != nil {
-			return tools.ValueSchema{}, false
-		}
-		return schema, true
-	case *jsonmap.Map, map[string]any:
-		data, err := json.Marshal(value)
-		if err != nil {
-			return tools.ValueSchema{}, false
-		}
-		var schema tools.ValueSchema
-		if json.Unmarshal(data, &schema) != nil {
-			return tools.ValueSchema{}, false
-		}
-		return schema, true
-	default:
+	data, err := json.Marshal(raw)
+	if err != nil {
 		return tools.ValueSchema{}, false
 	}
+	var schema tools.ValueSchema
+	if json.Unmarshal(data, &schema) != nil {
+		return tools.ValueSchema{}, false
+	}
+	return schema, true
 }

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -261,7 +261,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 
 	if toolbox != nil {
 		// Build tools first.
-		apiTools, err := toolsFromToolbox(toolbox, m.flatCustomTools, m.geminiToolSchemas)
+		apiTools, err := m.toolsFromToolbox(toolbox)
 		if err != nil {
 			return nil, err
 		}
@@ -1090,13 +1090,13 @@ func (m *ChatCompletionsAPI) chatAllowedToolEntries(names []string, apiTools []T
 	return allowed
 }
 
-func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools, geminiToolSchemas bool) ([]Tool, error) {
+func (m *ChatCompletionsAPI) toolsFromToolbox(toolbox *tools.Toolbox) ([]Tool, error) {
 	// customTool builds a custom tool declaration. The flat form mirrors the
 	// Responses API ({"type":"custom","name":…,"format":{"type":"grammar",
 	// "syntax":…,"definition":…}}) for endpoints that forward the tools array
 	// there; the nested form is Chat Completions' own wrapper.
 	customTool := func(t tools.Tool, format map[string]any) Tool {
-		if flatCustomTools {
+		if m.flatCustomTools {
 			if format["type"] == "grammar" {
 				grammar := format["grammar"].(map[string]any)
 				format = map[string]any{
@@ -1119,7 +1119,7 @@ func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools, geminiToolSchemas
 		switch g := t.Grammar().(type) {
 		case tools.JSONGrammar:
 			if schema := g.Schema(); schema != nil {
-				if geminiToolSchemas {
+				if m.geminiToolSchemas {
 					narrowed := geminischema.SanitizeFunction(*schema)
 					schema = &narrowed
 				}
@@ -1151,7 +1151,7 @@ func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools, geminiToolSchemas
 }
 
 func Tools(toolbox *tools.Toolbox) []Tool {
-	apiTools, err := toolsFromToolbox(toolbox, false, false)
+	apiTools, err := (&ChatCompletionsAPI{}).toolsFromToolbox(toolbox)
 	if err != nil {
 		panic(err)
 	}

--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/internal/geminischema"
 	"github.com/flitsinc/go-llms/llms"
 	"github.com/flitsinc/go-llms/tools"
 )
@@ -39,6 +40,9 @@ type ChatCompletionsAPI struct {
 	flatCustomTools bool
 	// When true, encode assistant Thought items as reasoning_details for replay.
 	assistantReasoningReplay bool
+	// When true, narrow function tool schemas to the subset Gemini accepts
+	// before sending them (see WithGeminiToolSchemas).
+	geminiToolSchemas bool
 
 	customPayloadValues map[string]any
 	customHeaders       map[string]string
@@ -110,6 +114,20 @@ func (m *ChatCompletionsAPI) WithCacheControlPromptHints() *ChatCompletionsAPI {
 // grammar-constrained decoding).
 func (m *ChatCompletionsAPI) WithFlatCustomTools() *ChatCompletionsAPI {
 	m.flatCustomTools = true
+	return m
+}
+
+// WithGeminiToolSchemas narrows function tool schemas to the subset Google's
+// function-calling API accepts before they are sent. Use this whenever an
+// OpenAI-compatible gateway routes the request to Gemini upstream.
+//
+// Without it, a toolbox built for OpenAI's strict mode — "additionalProperties"
+// on every object, plus the JSON Schema validation vocabulary Gemini has never
+// implemented — is rejected by Google with a 400 before a single token is
+// billed, so every tool-calling request fails. The native google provider has
+// always narrowed schemas this way; this makes the gateway path agree.
+func (m *ChatCompletionsAPI) WithGeminiToolSchemas() *ChatCompletionsAPI {
+	m.geminiToolSchemas = true
 	return m
 }
 
@@ -243,7 +261,7 @@ func (m *ChatCompletionsAPI) BuildPayload(
 
 	if toolbox != nil {
 		// Build tools first.
-		apiTools, err := toolsFromToolbox(toolbox, m.flatCustomTools)
+		apiTools, err := toolsFromToolbox(toolbox, m.flatCustomTools, m.geminiToolSchemas)
 		if err != nil {
 			return nil, err
 		}
@@ -1072,7 +1090,7 @@ func (m *ChatCompletionsAPI) chatAllowedToolEntries(names []string, apiTools []T
 	return allowed
 }
 
-func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools bool) ([]Tool, error) {
+func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools, geminiToolSchemas bool) ([]Tool, error) {
 	// customTool builds a custom tool declaration. The flat form mirrors the
 	// Responses API ({"type":"custom","name":…,"format":{"type":"grammar",
 	// "syntax":…,"definition":…}}) for endpoints that forward the tools array
@@ -1101,6 +1119,10 @@ func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools bool) ([]Tool, err
 		switch g := t.Grammar().(type) {
 		case tools.JSONGrammar:
 			if schema := g.Schema(); schema != nil {
+				if geminiToolSchemas {
+					narrowed := geminischema.SanitizeFunction(*schema)
+					schema = &narrowed
+				}
 				apiTools = append(apiTools, Tool{Type: "function", Function: schema})
 			}
 		case tools.TextGrammar:
@@ -1129,7 +1151,7 @@ func toolsFromToolbox(toolbox *tools.Toolbox, flatCustomTools bool) ([]Tool, err
 }
 
 func Tools(toolbox *tools.Toolbox) []Tool {
-	apiTools, err := toolsFromToolbox(toolbox, false)
+	apiTools, err := toolsFromToolbox(toolbox, false, false)
 	if err != nil {
 		panic(err)
 	}

--- a/openai/chatcompletions_flat_custom_test.go
+++ b/openai/chatcompletions_flat_custom_test.go
@@ -36,7 +36,7 @@ func marshalToolsArray(t *testing.T, apiTools []Tool) []map[string]any {
 }
 
 func TestToolsFromToolbox_FlatCustomTools(t *testing.T) {
-	apiTools, err := toolsFromToolbox(flatModeToolbox(), true)
+	apiTools, err := toolsFromToolbox(flatModeToolbox(), true, false)
 	if err != nil {
 		t.Fatalf("toolsFromToolbox: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestToolsFromToolbox_FlatCustomTools(t *testing.T) {
 }
 
 func TestToolsFromToolbox_NestedCustomToolsUnchanged(t *testing.T) {
-	apiTools, err := toolsFromToolbox(flatModeToolbox(), false)
+	apiTools, err := toolsFromToolbox(flatModeToolbox(), false, false)
 	if err != nil {
 		t.Fatalf("toolsFromToolbox: %v", err)
 	}

--- a/openai/chatcompletions_flat_custom_test.go
+++ b/openai/chatcompletions_flat_custom_test.go
@@ -36,7 +36,7 @@ func marshalToolsArray(t *testing.T, apiTools []Tool) []map[string]any {
 }
 
 func TestToolsFromToolbox_FlatCustomTools(t *testing.T) {
-	apiTools, err := toolsFromToolbox(flatModeToolbox(), true, false)
+	apiTools, err := (&ChatCompletionsAPI{flatCustomTools: true}).toolsFromToolbox(flatModeToolbox())
 	if err != nil {
 		t.Fatalf("toolsFromToolbox: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestToolsFromToolbox_FlatCustomTools(t *testing.T) {
 }
 
 func TestToolsFromToolbox_NestedCustomToolsUnchanged(t *testing.T) {
-	apiTools, err := toolsFromToolbox(flatModeToolbox(), false, false)
+	apiTools, err := (&ChatCompletionsAPI{}).toolsFromToolbox(flatModeToolbox())
 	if err != nil {
 		t.Fatalf("toolsFromToolbox: %v", err)
 	}

--- a/openai/chatcompletions_gemini_schema_test.go
+++ b/openai/chatcompletions_gemini_schema_test.go
@@ -1,0 +1,110 @@
+package openai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/flitsinc/go-llms/tools"
+)
+
+// editorShapedToolbox reproduces the tool declaration an OpenAI-strict client
+// sends: "additionalProperties": false on every object, optional fields encoded
+// as anyOf with a null branch, and validation keywords Gemini has never
+// implemented. Properties arrive as decoded JSON (not typed ValueSchema)
+// because that is what an external caller's schema looks like after the API
+// unmarshals it off the wire.
+func editorShapedToolbox(t *testing.T) *tools.Toolbox {
+	t.Helper()
+	const raw = `{
+		"name": "edit_module",
+		"description": "Edit a module.",
+		"parameters": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["moduleId", "edits"],
+			"properties": {
+				"moduleId": {"type": "string", "pattern": "^mod_[a-z]+$", "minLength": 4},
+				"kind": {"const": "component"},
+				"edits": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"properties": {
+							"find": {"type": "string"},
+							"replace": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+						}
+					}
+				}
+			}
+		}
+	}`
+	var schema tools.FunctionSchema
+	if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	return tools.Box(tools.External("Edit module", &schema,
+		func(r tools.Runner, params json.RawMessage) tools.Result { return tools.SuccessFromString("ok") }))
+}
+
+func toolsJSON(t *testing.T, toolbox *tools.Toolbox, geminiToolSchemas bool) string {
+	t.Helper()
+	apiTools, err := toolsFromToolbox(toolbox, true, geminiToolSchemas)
+	if err != nil {
+		t.Fatalf("toolsFromToolbox: %v", err)
+	}
+	data, err := json.Marshal(apiTools)
+	if err != nil {
+		t.Fatalf("marshal tools: %v", err)
+	}
+	return string(data)
+}
+
+// Gemini answers a declaration carrying any of these with a 400 before billing
+// a token, so none may survive into the request.
+var geminiRejectedKeywords = []string{"additionalProperties", "pattern", "minLength", "const"}
+
+func TestToolsFromToolbox_GeminiSchemasDropRejectedKeywords(t *testing.T) {
+	payload := toolsJSON(t, editorShapedToolbox(t), true)
+
+	for _, keyword := range geminiRejectedKeywords {
+		if strings.Contains(payload, keyword) {
+			t.Errorf("Gemini mode still sends %q, which Google rejects with a 400: %s", keyword, payload)
+		}
+	}
+
+	// Narrowing must not cost the model the information it needs to call the
+	// tool: the properties and their nesting have to survive intact.
+	for _, kept := range []string{"moduleId", "edits", "find", "replace", "items"} {
+		if !strings.Contains(payload, kept) {
+			t.Errorf("Gemini mode dropped %q, which the model needs to call the tool: %s", kept, payload)
+		}
+	}
+}
+
+// The narrowing is a workaround for one upstream, not an improvement. Applying
+// it to every OpenRouter model would silently weaken strict-mode tool calling
+// on providers that honour these keywords.
+func TestToolsFromToolbox_NonGeminiKeepsStrictKeywords(t *testing.T) {
+	payload := toolsJSON(t, editorShapedToolbox(t), false)
+
+	if !strings.Contains(payload, "additionalProperties") {
+		t.Errorf("non-Gemini mode must leave strict-mode schemas alone: %s", payload)
+	}
+}
+
+// A toolbox is shared across providers and across turns. Narrowing a schema for
+// Gemini must not reach back into it, or an unrelated request would silently
+// inherit the weakened copy.
+func TestToolsFromToolbox_GeminiSchemasDoNotMutateToolbox(t *testing.T) {
+	toolbox := editorShapedToolbox(t)
+
+	before := toolsJSON(t, toolbox, false)
+	toolsJSON(t, toolbox, true) // the pass that could write through to the toolbox
+	after := toolsJSON(t, toolbox, false)
+
+	if before != after {
+		t.Errorf("narrowing for Gemini mutated the shared toolbox\nbefore: %s\nafter:  %s", before, after)
+	}
+}

--- a/openai/chatcompletions_gemini_schema_test.go
+++ b/openai/chatcompletions_gemini_schema_test.go
@@ -26,6 +26,8 @@ func editorShapedToolbox(t *testing.T) *tools.Toolbox {
 			"properties": {
 				"moduleId": {"type": "string", "pattern": "^mod_[a-z]+$", "minLength": 4},
 				"kind": {"const": "component"},
+				"source": {"type": "string", "enum": ["sandbox", "workflow", ""]},
+				"status": {"type": "string", "enum": ["running", "failed"]},
 				"edits": {
 					"type": "array",
 					"items": {
@@ -80,6 +82,33 @@ func TestToolsFromToolbox_GeminiSchemasDropRejectedKeywords(t *testing.T) {
 	for _, kept := range []string{"moduleId", "edits", "find", "replace", "items"} {
 		if !strings.Contains(payload, kept) {
 			t.Errorf("Gemini mode dropped %q, which the model needs to call the tool: %s", kept, payload)
+		}
+	}
+}
+
+// The empty string is the member Google refuses, and callers use it as their
+// "no filter" choice. Dropping the whole enum keeps that choice reachable as a
+// plain string; dropping just the member would take the option away.
+func TestToolsFromToolbox_GeminiDropsEnumOfferingEmptyString(t *testing.T) {
+	payload := toolsJSON(t, editorShapedToolbox(t), true)
+
+	if strings.Contains(payload, `"sandbox"`) {
+		t.Errorf("an enum offering \"\" must be dropped whole, not filtered: %s", payload)
+	}
+	if !strings.Contains(payload, `"source"`) {
+		t.Errorf("dropping the enum must keep the property itself: %s", payload)
+	}
+}
+
+// Enums are the reason this narrowing has to be keyword-aware rather than a
+// blanket strip: Gemini supports them, and throwing them away silently removes
+// a constraint the model relies on.
+func TestToolsFromToolbox_GeminiKeepsValidEnums(t *testing.T) {
+	payload := toolsJSON(t, editorShapedToolbox(t), true)
+
+	for _, kept := range []string{`"running"`, `"failed"`} {
+		if !strings.Contains(payload, kept) {
+			t.Errorf("Gemini accepts enums without \"\"; %s must survive: %s", kept, payload)
 		}
 	}
 }

--- a/openai/chatcompletions_gemini_schema_test.go
+++ b/openai/chatcompletions_gemini_schema_test.go
@@ -50,7 +50,8 @@ func editorShapedToolbox(t *testing.T) *tools.Toolbox {
 
 func toolsJSON(t *testing.T, toolbox *tools.Toolbox, geminiToolSchemas bool) string {
 	t.Helper()
-	apiTools, err := toolsFromToolbox(toolbox, true, geminiToolSchemas)
+	api := &ChatCompletionsAPI{flatCustomTools: true, geminiToolSchemas: geminiToolSchemas}
+	apiTools, err := api.toolsFromToolbox(toolbox)
 	if err != nil {
 		t.Fatalf("toolsFromToolbox: %v", err)
 	}

--- a/openrouter/gemini_tool_schema_test.go
+++ b/openrouter/gemini_tool_schema_test.go
@@ -1,0 +1,113 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/flitsinc/go-llms/content"
+	"github.com/flitsinc/go-llms/llms"
+	"github.com/flitsinc/go-llms/tools"
+)
+
+// strictToolbox is a tool declared the way an OpenAI-strict client declares
+// one: "additionalProperties": false on every object plus validation keywords
+// that Gemini rejects outright.
+func strictToolbox(t *testing.T) *tools.Toolbox {
+	t.Helper()
+	const raw = `{
+		"name": "edit_module",
+		"description": "Edit a module.",
+		"parameters": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["moduleId"],
+			"properties": {
+				"moduleId": {"type": "string", "pattern": "^mod_"},
+				"edits": {
+					"type": "array",
+					"items": {"type": "object", "additionalProperties": false,
+						"properties": {"find": {"type": "string"}}}
+				}
+			}
+		}
+	}`
+	var schema tools.FunctionSchema
+	require.NoError(t, json.Unmarshal([]byte(raw), &schema))
+	return tools.Box(tools.External("Edit module", &schema,
+		func(r tools.Runner, params json.RawMessage) tools.Result { return tools.SuccessFromString("ok") }))
+}
+
+func payloadJSON(t *testing.T, model string) string {
+	t.Helper()
+	payload, err := New("", model).BuildPayload(
+		content.FromText("system"),
+		[]llms.Message{{Role: "user", Content: content.FromText("hi")}},
+		strictToolbox(t),
+		nil,
+	)
+	require.NoError(t, err)
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// Every Gemini model reached through OpenRouter answered a strict-mode tool
+// declaration with a 400 before this narrowing existed, so the request built
+// for one must not carry the keywords Google refuses.
+func TestNew_GeminiModelsNarrowToolSchemas(t *testing.T) {
+	for _, model := range []string{
+		"google/gemini-3.7-flash",
+		"google/gemini-3-flash-preview",
+		"google/gemini-3.1-pro-preview",
+	} {
+		t.Run(model, func(t *testing.T) {
+			payload := payloadJSON(t, model)
+			for _, keyword := range []string{"additionalProperties", "pattern"} {
+				require.NotContains(t, payload, keyword,
+					"Gemini rejects %q with a 400; it must not reach the wire", keyword)
+			}
+			require.Contains(t, payload, "moduleId", "the tool's properties must survive narrowing")
+		})
+	}
+}
+
+// Narrowing is a Gemini workaround, not a default. Models whose upstream
+// honours strict mode must keep receiving the full schema.
+func TestNew_NonGeminiModelsKeepStrictToolSchemas(t *testing.T) {
+	for _, model := range []string{
+		"openai/gpt-5.6-luna",
+		"anthropic/claude-sonnet-4",
+		"moonshotai/kimi-k2.7-code",
+		// Google's non-Gemini listings are served by third-party endpoints
+		// that take the full schema, so the prefix check must not catch them.
+		"google/gemma-3-27b-it",
+	} {
+		t.Run(model, func(t *testing.T) {
+			require.Contains(t, payloadJSON(t, model), "additionalProperties",
+				"strict-mode schemas must reach providers that honour them")
+		})
+	}
+}
+
+func TestIsGeminiModel(t *testing.T) {
+	for model, want := range map[string]bool{
+		"google/gemini-3.7-flash":       true,
+		"google/gemini-3-flash-preview": true,
+		"google/gemma-3-27b-it":         false,
+		"openai/gpt-5.6-luna":           false,
+		"gemini-3.7-flash":              false, // not an OpenRouter id
+	} {
+		require.Equalf(t, want, isGeminiModel(model), "isGeminiModel(%q)", model)
+	}
+}
+
+// Guards the reason the check lives on the model id: a Gemini row added later
+// gets the narrowing without anyone remembering to ask for it.
+func TestNew_GeminiNarrowingNeedsNoOptIn(t *testing.T) {
+	payload := payloadJSON(t, "google/gemini-99-future-preview")
+	require.False(t, strings.Contains(payload, "additionalProperties"),
+		"a future Gemini row must be narrowed by default, not by opt-in")
+}

--- a/openrouter/gemini_tool_schema_test.go
+++ b/openrouter/gemini_tool_schema_test.go
@@ -2,7 +2,6 @@ package openrouter
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,12 +101,4 @@ func TestIsGeminiModel(t *testing.T) {
 	} {
 		require.Equalf(t, want, isGeminiModel(model), "isGeminiModel(%q)", model)
 	}
-}
-
-// Guards the reason the check lives on the model id: a Gemini row added later
-// gets the narrowing without anyone remembering to ask for it.
-func TestNew_GeminiNarrowingNeedsNoOptIn(t *testing.T) {
-	payload := payloadJSON(t, "google/gemini-99-future-preview")
-	require.False(t, strings.Contains(payload, "additionalProperties"),
-		"a future Gemini row must be narrowed by default, not by opt-in")
 }

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -1,6 +1,10 @@
 package openrouter
 
-import "github.com/flitsinc/go-llms/openai"
+import (
+	"strings"
+
+	"github.com/flitsinc/go-llms/openai"
+)
 
 // Provider is an OpenRouter-configured Chat Completions client.
 type Provider = openai.ChatCompletionsAPI
@@ -15,11 +19,28 @@ type Reasoning struct {
 // because OpenRouter forwards the tools array into a Responses API request
 // upstream, where the nested Chat Completions wrapper is rejected.
 func New(apiKey, model string) *Provider {
-	return openai.New(apiKey, model).
+	provider := openai.New(apiKey, model).
 		WithEndpoint("https://openrouter.ai/api/v1/chat/completions", "OpenRouter").
 		WithCacheControlPromptHints().
 		WithAssistantReasoningReplay().
 		WithFlatCustomTools()
+	if isGeminiModel(model) {
+		provider = provider.WithGeminiToolSchemas()
+	}
+	return provider
+}
+
+// isGeminiModel reports whether an OpenRouter model id is served by Google's
+// Gemini API upstream, which accepts a narrower tool schema than the rest of
+// OpenRouter's catalogue.
+//
+// The check is on the model id rather than a caller-supplied option on purpose:
+// a Gemini row that forgets to opt in does not degrade, it fails every
+// tool-calling request with a 400, so the safe behaviour has to be the one you
+// get by default. Only "google/gemini*" qualifies — Google's other listings
+// (Gemma) are served by third-party endpoints that take the full schema.
+func isGeminiModel(model string) bool {
+	return strings.HasPrefix(model, "google/gemini")
 }
 
 // NewWithReasoning returns an OpenRouter-configured Chat Completions client

--- a/tools/schema.go
+++ b/tools/schema.go
@@ -44,6 +44,8 @@ type ValueSchema struct {
 	Required []string `json:"required,omitempty"`
 	// AnyOf specifies that the value must conform to at least one of the provided schemas.
 	AnyOf []ValueSchema `json:"anyOf,omitempty"`
+	// Enum restricts a string value to a fixed set of choices.
+	Enum []string `json:"enum,omitempty"`
 }
 
 // UnmarshalJSON ensures map-like schema fields preserve insertion order via jsonmap.


### PR DESCRIPTION
## The bug

Every tool-calling request to a Gemini model routed through OpenRouter fails with HTTP 400 before a token is billed. Measured in production over 30 days: `durable-editor` + `openrouter/gemini-3.7-flash` was **916 400s in 919 calls**, and the remaining 3 returned `empty_response`. The Biscuit editor benchmark scored **0/302** on that model.

The same model outside a tool-calling caller is clean — 3,480 calls, zero errors — and all 351,761 successful Gemini-over-OpenRouter calls in that window made zero tool calls. Tool calling had never worked on this path.

## Root cause

Google, via OpenRouter, with the real editor toolbox:

```
* GenerateContentRequest.tools[0].function_declarations[11].parameters.properties[source].enum[3]: cannot be empty
* GenerateContentRequest.tools[0].function_declarations[12].parameters.properties[status].enum[3]: cannot be empty
```

Two tools offer `""` as their "no filter" choice — `readActivityLog.source` is `["sandbox","workflow","chat",""]` and `listWorkflowRuns.status` is `["running","completed","failed",""]`. Google refuses an empty enum member and rejects the entire request.

It only bites on this transport because the narrowing existed in one of the two ways to reach Gemini: `sanitizeSchemaForGemini` lived in `google/`, so the native API got usable schemas while OpenAI-compatible gateways shipped them verbatim.

## The fix

- `internal/geminischema` — one implementation, shared by both transports.
- `ChatCompletionsAPI.WithGeminiToolSchemas()`, enabled automatically by `openrouter.New` for `google/gemini*` ids. Detection is on the model id rather than an opt-in because a Gemini row that forgets to opt in does not degrade, it fails every request.
- An enum offering `""` is **dropped whole** rather than having the member filtered out. Callers mean "no filter" by it, so removing just the member would take the option away instead of the error; dropping the enum leaves a plain string that still accepts every value the caller meant to offer.
- `ValueSchema` gains an `Enum` field so valid enums survive. Without it the narrowing discarded every enum — which is also why the **native google provider has been silently stripping enums from Gemini tool declarations** for as long as it has had a sanitizer. That is a second, quieter bug this fixes.
- Sanitizing returns a copy. The old code took a shallow `FunctionSchema` copy but shared its `Properties` map, so narrowing for Gemini wrote through to the caller's toolbox.

## Verification

End to end against the live upstream, all 26 real editor tools:

| | result |
|---|---|
| schemas sent verbatim (today) | **HTTP 400**, `enum[3]: cannot be empty` |
| narrowed by this branch | **HTTP 200**, `finish_reason=tool_calls`, called `readActivityLog` |

Unit tests are mutation-checked: disabling the sanitizer fails the `openai` tests, disabling model detection fails the `openrouter` tests. Full suite, `go vet` and `gofmt` clean. Non-Gemini models (`openai/*`, `anthropic/*`, `google/gemma-*`) keep their full strict-mode schemas.

## Follow-ups (not in this PR)

- The empty-string enum member is an anti-pattern at the source — an enum value meaning "unset" should be an optional field. Worth fixing in the Biscuit UI so no provider sees it.
- The streaming error path appears to lose `metadata.raw`: production spans recorded `provider_name` but no upstream message, so Google's actual reason above was invisible in telemetry. The non-streaming path parses it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)