### PR TITLE
Preserve enum members in Gemini tool declarations (BSCT-3198)

### DIFF
--- a/google/gemini3_test.go
+++ b/google/gemini3_test.go
@@ -2359,3 +2359,85 @@ func TestSanitizeSchemaForGemini_MapStringAny(t *testing.T) {
 		t.Errorf("Expected description 'A positive count', got %v", countSchema["description"])
 	}
 }
+
+// TestSanitizeSchemaForGemini_PreservesEnums tests that enum members survive
+// sanitization, both on top-level and nested properties (BSCT-3198: the
+// round-trip through tools.ValueSchema used to drop every enum).
+func TestSanitizeSchemaForGemini_PreservesEnums(t *testing.T) {
+	modeProp := jsonmap.New()
+	modeProp.Set("type", "string")
+	modeProp.Set("enum", []string{"fast", "slow"})
+
+	kindProp := jsonmap.New()
+	kindProp.Set("type", "string")
+	kindProp.Set("enum", []string{"a", "b"})
+	innerProps := jsonmap.New()
+	innerProps.Set("kind", kindProp)
+	nestedProp := jsonmap.New()
+	nestedProp.Set("type", "object")
+	nestedProp.Set("properties", innerProps)
+
+	props := jsonmap.New()
+	props.Set("mode", modeProp)
+	props.Set("nested", nestedProp)
+
+	schema := tools.FunctionSchema{
+		Name:        "test_func",
+		Description: "Test function",
+		Parameters: tools.ValueSchema{
+			Type:       "object",
+			Properties: props,
+		},
+	}
+
+	payloadCh := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var payload map[string]any
+		json.NewDecoder(r.Body).Decode(&payload)
+		payloadCh <- payload
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`data: {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}` + "\n"))
+	}))
+	defer server.Close()
+
+	tb := tools.Box(
+		tools.External("Test", &schema, func(r tools.Runner, params json.RawMessage) tools.Result {
+			return tools.SuccessFromString("ok")
+		}),
+	)
+
+	model := New("gemini-2.0-flash").WithGeminiAPI("fake-key")
+	model.endpoint = server.URL
+
+	ctx := context.Background()
+	stream := model.Generate(ctx, nil, []llms.Message{
+		{Role: "user", Content: content.FromText("test")},
+	}, tb, nil)
+
+	if err := stream.Err(); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	payload := <-payloadCh
+
+	toolsPayload := payload["tools"].(map[string]any)
+	declarations := toolsPayload["functionDeclarations"].([]any)
+	decl := declarations[0].(map[string]any)
+	params := decl["parameters"].(map[string]any)
+	properties := params["properties"].(map[string]any)
+
+	modeSchema := properties["mode"].(map[string]any)
+	if !reflect.DeepEqual(modeSchema["enum"], []any{"fast", "slow"}) {
+		t.Errorf("mode enum = %v, want [fast slow]", modeSchema["enum"])
+	}
+
+	nestedSchema := properties["nested"].(map[string]any)
+	nestedProps2 := nestedSchema["properties"].(map[string]any)
+	kindSchema := nestedProps2["kind"].(map[string]any)
+	if !reflect.DeepEqual(kindSchema["enum"], []any{"a", "b"}) {
+		t.Errorf("nested kind enum = %v, want [a b]", kindSchema["enum"])
+	}
+}

--- a/tools/schema.go
+++ b/tools/schema.go
@@ -40,6 +40,11 @@ type ValueSchema struct {
 	// It can be a boolean (true to allow any, false to disallow) or a ValueSchema defining the type of allowed additional properties.
 	// Only used when Type is "object".
 	AdditionalProperties any `json:"additionalProperties,omitempty"`
+	// Enum restricts the value to a fixed set of members. JSON Schema allows
+	// members of any type, so this is []any rather than []string; a stricter
+	// element type would make the whole schema fail to unmarshal when a
+	// numeric enum appears.
+	Enum []any `json:"enum,omitempty"`
 	// Required lists the names of properties that must be present when Type is "object".
 	Required []string `json:"required,omitempty"`
 	// AnyOf specifies that the value must conform to at least one of the provided schemas.

--- a/tools/schema_test.go
+++ b/tools/schema_test.go
@@ -46,6 +46,41 @@ func TestValueSchema_AnyOf(t *testing.T) {
 	assert.JSONEq(t, inputJSON, string(outputJSON), "Output JSON should match input JSON for anyOf structure")
 }
 
+// TestValueSchema_EnumRoundTrip tests that enum members survive a JSON
+// round-trip through ValueSchema, including non-string members.
+func TestValueSchema_EnumRoundTrip(t *testing.T) {
+	inputJSON := `{
+		"type": "object",
+		"properties": {
+			"mode": { "type": "string", "enum": ["fast", "slow"] },
+			"level": { "type": "integer", "enum": [1, 2, 3] }
+		}
+	}`
+
+	var schema ValueSchema
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &schema))
+
+	rawMode, ok := schema.Properties.Get("mode")
+	require.True(t, ok)
+	modeJSON, err := json.Marshal(rawMode)
+	require.NoError(t, err)
+	var mode ValueSchema
+	require.NoError(t, json.Unmarshal(modeJSON, &mode))
+	assert.Equal(t, []any{"fast", "slow"}, mode.Enum)
+
+	rawLevel, ok := schema.Properties.Get("level")
+	require.True(t, ok)
+	levelJSON, err := json.Marshal(rawLevel)
+	require.NoError(t, err)
+	var level ValueSchema
+	require.NoError(t, json.Unmarshal(levelJSON, &level))
+	assert.Equal(t, []any{float64(1), float64(2), float64(3)}, level.Enum)
+
+	outputJSON, err := json.Marshal(schema)
+	require.NoError(t, err)
+	assert.JSONEq(t, inputJSON, string(outputJSON))
+}
+
 // TestGenerateSchema checks that the JSON schema is generated correctly from the Params struct.
 // Moved from tool_test.go
 func TestGenerateSchema(t *testing.T) {


### PR DESCRIPTION
## The bug

`sanitizeSchemaForGemini` narrows every nested property by round-tripping it through `tools.ValueSchema`, which keeps only the fields it declares. `ValueSchema` had no `Enum` field, so **every enum was silently dropped** from every tool declaration sent to Gemini on the native google provider. The editor sends 10 enums across its 26 tools; all 10 were discarded. Gemini supports `enum` in function declarations, so this was pure loss: the model was told a field is a free-form string when we meant it to pick from a fixed set.

This is the narrow remainder of the closed #79 — that PR fixed the OpenRouter outage in the wrong layer, but its finding that the native sanitizer strips valid enums stands. Tracked as [BSCT-3198](https://linear.app/bsct/issue/BSCT-3198).

## The fix

Add `Enum` to `ValueSchema` so enums survive the round-trip. It is `[]any` rather than `[]string`: JSON Schema allows enum members of any type, and a stricter element type would make a numeric enum fail the round-trip unmarshal — the sanitizer's error path would then skip that property entirely, leaving it *unsanitized*. `[]any` unmarshals anything and marshals members back verbatim.

No sanitizer-side filtering of enum members: per the #79 investigation, Google accepts enums directly; the one thing it refuses (`""` members) was fixed at the source in builder #8128, with a build-time guard keeping it out going forward.

## Sequencing

Builder #8128 (merged 2026-08-20) removed the `""` enum members from `readActivityLog.source` and `listWorkflowRuns.status`. Before that, preserving enums would have turned a silent quality loss into a hard 400 on the native path. It is merged, so this is now safe to land.

## Verification

- `TestSanitizeSchemaForGemini_PreservesEnums` asserts the actual request payload contains both a top-level and a nested enum, mirroring the ticket's probe. Mutation-checked: with the `Enum` field removed, the test fails (enum absent from the payload).
- `TestValueSchema_EnumRoundTrip` covers string and numeric members through unmarshal/marshal.
- **Live end-to-end against Vertex AI** (`flits-builder`, `gemini-2.5-flash`, `global`): a declaration with `source: enum ["sandbox","workflow","chat"]` and a nested `status` enum — mirroring the post-#8128 editor shape — through this branch's provider returned **HTTP 200** and a tool call with a valid member (`{"source": "workflow"}`).
- Full suite, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)