### PR TITLE
Make sanitizeSchemaForGemini return a copy instead of mutating the toolbox (BSCT-3199)

### DIFF
--- a/google/gemini3_test.go
+++ b/google/gemini3_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -2015,6 +2016,92 @@ func TestSanitizeSchemaForGemini_NestedProperties(t *testing.T) {
 	// Verify supported fields are preserved
 	if valueSchema["type"] != "number" {
 		t.Errorf("nested value type should be 'number', got %v", valueSchema["type"])
+	}
+}
+
+// TestSanitizeSchemaForGemini_DoesNotMutateToolbox tests that building a Gemini
+// request leaves the caller's tool schemas byte-identical (BSCT-3199: the
+// sanitizer used to write narrowed values back through the shared Properties
+// map, Items pointer, and AnyOf backing array).
+func TestSanitizeSchemaForGemini_DoesNotMutateToolbox(t *testing.T) {
+	var schema tools.FunctionSchema
+	if err := json.Unmarshal([]byte(`{
+		"name": "test_func",
+		"description": "Test function",
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"email": {"type": "string", "pattern": "^[^@]+@[^@]+$"},
+				"nested": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"kind": {"type": "string", "const": "a"}
+					}
+				},
+				"list": {"type": "array", "items": {"type": "number", "exclusiveMinimum": 0}},
+				"choice": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]}
+			},
+			"additionalProperties": false
+		}
+	}`), &schema); err != nil {
+		t.Fatalf("failed to unmarshal schema: %v", err)
+	}
+
+	before, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("failed to marshal schema before request: %v", err)
+	}
+
+	payloadCh := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var payload map[string]any
+		json.NewDecoder(r.Body).Decode(&payload)
+		payloadCh <- payload
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`data: {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}` + "\n"))
+	}))
+	defer server.Close()
+
+	tb := tools.Box(
+		tools.External("Test", &schema, func(r tools.Runner, params json.RawMessage) tools.Result {
+			return tools.SuccessFromString("ok")
+		}),
+	)
+
+	model := New("gemini-2.0-flash").WithGeminiAPI("fake-key")
+	model.endpoint = server.URL
+
+	ctx := context.Background()
+	stream := model.Generate(ctx, nil, []llms.Message{
+		{Role: "user", Content: content.FromText("test")},
+	}, tb, nil)
+
+	if err := stream.Err(); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	payload := <-payloadCh
+
+	// The request itself must be narrowed, or this test proves nothing.
+	toolsPayload := payload["tools"].(map[string]any)
+	declarations := toolsPayload["functionDeclarations"].([]any)
+	decl := declarations[0].(map[string]any)
+	params := decl["parameters"].(map[string]any)
+	properties := params["properties"].(map[string]any)
+	if _, exists := properties["email"].(map[string]any)["pattern"]; exists {
+		t.Fatal("pattern should have been stripped from the request payload")
+	}
+
+	after, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("failed to marshal schema after request: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("toolbox schema was mutated by building a Gemini request\nbefore: %s\nafter:  %s", before, after)
 	}
 }
 

--- a/google/google.go
+++ b/google/google.go
@@ -20,65 +20,71 @@ import (
 	"github.com/flitsinc/go-llms/tools"
 )
 
-// sanitizeSchemaForGemini recursively removes unsupported JSON Schema properties
-// to make schemas compatible with Google's Gemini API. This includes:
+// sanitizeSchemaForGemini returns a copy of the schema with JSON Schema
+// properties unsupported by Google's Gemini API removed. This includes:
 //   - Setting AdditionalProperties to nil
 //   - Stripping unsupported keywords like exclusiveMinimum, const, pattern, etc.
 //     by round-tripping through tools.ValueSchema which only has supported fields.
-func sanitizeSchemaForGemini(schema *tools.ValueSchema) {
-	schema.AdditionalProperties = nil
+//
+// The input is never mutated: a Toolbox outlives a single request and can be
+// shared across providers, so narrowing must not write through to the caller's
+// schemas.
+func sanitizeSchemaForGemini(schema tools.ValueSchema) tools.ValueSchema {
+	out := schema
+	out.AdditionalProperties = nil
 
 	if schema.Items != nil {
-		sanitizeSchemaForGemini(schema.Items)
+		items := sanitizeSchemaForGemini(*schema.Items)
+		out.Items = &items
 	}
 
 	if schema.Properties != nil {
+		props := jsonmap.New()
 		for _, k := range schema.Properties.Keys() {
 			raw, ok := schema.Properties.Get(k)
 			if !ok {
 				continue
 			}
-
-			var v tools.ValueSchema
-			switch val := raw.(type) {
-			case tools.ValueSchema:
-				v = val
-			case *jsonmap.Map:
-				// Property is a nested map from jsonmap - marshal to JSON then
-				// unmarshal into ValueSchema to strip unsupported fields.
-				data, err := json.Marshal(val)
-				if err != nil {
-					continue
-				}
-				if err := json.Unmarshal(data, &v); err != nil {
-					continue
-				}
-			case map[string]any:
-				// Property is a generic map - marshal to JSON then unmarshal
-				// into ValueSchema to strip unsupported fields.
-				data, err := json.Marshal(val)
-				if err != nil {
-					continue
-				}
-				if err := json.Unmarshal(data, &v); err != nil {
-					continue
-				}
-			case json.RawMessage:
-				if err := json.Unmarshal(val, &v); err != nil {
-					continue
-				}
-			default:
+			v, err := propertyValueSchema(raw)
+			if err != nil {
+				// Keep the property as-is rather than dropping it; this matches
+				// the previous behavior of leaving undecodable values untouched.
+				props.Set(k, raw)
 				continue
 			}
-
-			sanitizeSchemaForGemini(&v)
-			schema.Properties.Set(k, v)
+			props.Set(k, sanitizeSchemaForGemini(v))
 		}
+		out.Properties = props
 	}
 
-	for i := range schema.AnyOf {
-		sanitizeSchemaForGemini(&schema.AnyOf[i])
+	if len(schema.AnyOf) > 0 {
+		anyOf := make([]tools.ValueSchema, len(schema.AnyOf))
+		for i, sub := range schema.AnyOf {
+			anyOf[i] = sanitizeSchemaForGemini(sub)
+		}
+		out.AnyOf = anyOf
 	}
+
+	return out
+}
+
+// propertyValueSchema decodes a property value in whatever shape it was stored
+// (tools.ValueSchema from tools.Func, *jsonmap.Map off the wire, or any other
+// JSON-marshalable form) into a tools.ValueSchema, which keeps only the fields
+// Gemini supports.
+func propertyValueSchema(raw any) (tools.ValueSchema, error) {
+	if v, ok := raw.(tools.ValueSchema); ok {
+		return v, nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return tools.ValueSchema{}, err
+	}
+	var v tools.ValueSchema
+	if err := json.Unmarshal(data, &v); err != nil {
+		return tools.ValueSchema{}, err
+	}
+	return v, nil
 }
 
 type Model struct {
@@ -401,7 +407,7 @@ func (m *Model) Generate(
 			switch g := tool.Grammar().(type) {
 			case tools.JSONGrammar:
 				schema := *g.Schema()
-				sanitizeSchemaForGemini(&schema.Parameters)
+				schema.Parameters = sanitizeSchemaForGemini(schema.Parameters)
 				declarations[i] = schema
 			default:
 				return &Stream{err: fmt.Errorf("google: unsupported tool grammar type %T", g)}


### PR DESCRIPTION
## The bug

`Model.Generate` narrows tool schemas for Gemini via:

```go
schema := *g.Schema()              // shallow copy of the FunctionSchema
sanitizeSchemaForGemini(&schema.Parameters)
```

The copy is one level deep. `Parameters.Properties` is a `*jsonmap.Map`, `Items` a pointer, and `AnyOf` a slice, so the sanitizer's recursive `Properties.Set(k, v)` writes — and its edits to `Items`/`AnyOf` elements — go straight through to the caller's toolbox. A `tools.Toolbox` outlives a single request and can be shared across providers: after one Gemini build, every later request on any provider silently ships the Gemini-narrowed schemas (`pattern`, `const`, `exclusiveMinimum`, `minLength`, nested `additionalProperties` — all gone). Currently masked because sanitizing is idempotent and a toolbox tends to see one provider per conversation, but it's request-ordering-dependent corruption that's invisible at the call site. Tracked as [BSCT-3199](https://linear.app/bsct/issue/BSCT-3199); the narrow remainder of the closed #79, sibling of #81.

## The fix

`sanitizeSchemaForGemini` is now a pure function: it takes and returns `tools.ValueSchema`, building a fresh `jsonmap` for `Properties` and fresh `Items`/`AnyOf` as it narrows. The five-case property type switch collapses into a single JSON round-trip (`propertyValueSchema`) — only two of those cases ever occurred in practice, and the round-trip handles every JSON-marshalable shape. Undecodable property values are kept as-is, matching the old error path's leave-untouched behavior.

## Verification

- `TestSanitizeSchemaForGemini_DoesNotMutateToolbox` runs a toolbox through a real `Generate` payload build, asserts the request was actually narrowed (`pattern` stripped), then asserts the toolbox schema is byte-identical to before.
- Mutation-checked against the old in-place sanitizer: the test fails, showing the toolbox after one Gemini build has lost `pattern`, `const`, `exclusiveMinimum`, `minLength`, and nested `additionalProperties`.
- All existing sanitizer tests (nested properties, anyOf, array items, jsonmap/map shapes) pass unchanged — the narrowing behavior itself is untouched.
- Full suite, `go vet`, `gofmt` clean.

Note for merge ordering with #81: both touch this function's area. #81 adds the `Enum` field it round-trips through; this PR changes how the round-trip is applied. Either order merges with at most a trivial conflict (the test in this PR is inserted mid-file to avoid #81's appended test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)