### PR TITLE
Add ChatCompletionsAPI.WithServerTools for provider-executed tools

### DIFF
--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -43,6 +43,13 @@ type ChatCompletionsAPI struct {
 	customPayloadValues map[string]any
 	customHeaders       map[string]string
 
+	// Provider-executed tools appended verbatim to the request's tools array,
+	// after the toolbox's function tools. These are tools the provider runs
+	// server-side (e.g. OpenRouter's "openrouter:web_search"), so they have
+	// non-function types the Tool struct cannot express and produce no
+	// client-side tool calls.
+	serverTools []any
+
 	// When set, include prompt_cache_retention in requests that contain a "long"
 	// cache hint. This is an OpenAI-specific feature.
 	promptCacheRetention string
@@ -150,6 +157,17 @@ func (m *ChatCompletionsAPI) WithCustomPayloadValue(key string, value any) *Chat
 	return m
 }
 
+// WithServerTools appends provider-executed tools to the request's tools
+// array, after any function tools from the toolbox. Each entry is marshaled
+// verbatim, so callers pass the provider's exact tool shape (e.g. OpenRouter's
+// {"type": "openrouter:web_search", ...}). Server tools run inside the
+// provider's request loop and never surface as client tool calls, so they are
+// not part of the toolbox and are exempt from tool_choice constraints.
+func (m *ChatCompletionsAPI) WithServerTools(serverTools ...any) *ChatCompletionsAPI {
+	m.serverTools = append(m.serverTools, serverTools...)
+	return m
+}
+
 // WithHeader sets an additional HTTP header on requests made by this client.
 func (m *ChatCompletionsAPI) WithHeader(key, value string) *ChatCompletionsAPI {
 	if m.customHeaders == nil {
@@ -241,6 +259,10 @@ func (m *ChatCompletionsAPI) BuildPayload(
 		payload[k] = v
 	}
 
+	if len(m.serverTools) > 0 && toolbox == nil {
+		payload["tools"] = m.serverTools
+	}
+
 	if toolbox != nil {
 		// Build tools first.
 		apiTools, err := toolsFromToolbox(toolbox, m.flatCustomTools)
@@ -248,7 +270,15 @@ func (m *ChatCompletionsAPI) BuildPayload(
 			return nil, err
 		}
 		// Always include full tools for cacheability; constrain with tool_choice
-		payload["tools"] = apiTools
+		if len(m.serverTools) > 0 {
+			combined := make([]any, 0, len(apiTools)+len(m.serverTools))
+			for _, apiTool := range apiTools {
+				combined = append(combined, apiTool)
+			}
+			payload["tools"] = append(combined, m.serverTools...)
+		} else {
+			payload["tools"] = apiTools
+		}
 
 		// Map tools.Choice to Chat Completions tool_choice.
 		// Chat Completions now supports an allowed_tools object similar to Responses API.

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -1107,3 +1107,36 @@ func TestChatCompletionsStream_LegacyReasoningFieldAloneStillStreams(t *testing.
 func intPtr(v int) *int {
 	return &v
 }
+
+func TestBuildPayload_ServerToolsAppendedAfterFunctionTools(t *testing.T) {
+	weatherSchema := tools.FunctionSchema{Name: "get_weather", Description: "Weather", Parameters: tools.ValueSchema{Type: "object"}}
+	tb := tools.Box(
+		tools.External("Weather", &weatherSchema, func(r tools.Runner, params json.RawMessage) tools.Result { return tools.SuccessFromString("ok") }),
+	)
+	webSearch := map[string]any{"type": "openrouter:web_search", "parameters": map[string]any{"engine": "exa"}}
+
+	m := NewChatCompletionsAPI("", "gpt-5").WithServerTools(webSearch)
+	payload, err := m.BuildPayload(content.FromText("hi"), nil, tb, nil)
+	require.NoError(t, err)
+
+	// Round-trip through JSON so both function and server tools compare in map form.
+	raw, err := json.Marshal(payload["tools"])
+	require.NoError(t, err)
+	var entries []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &entries))
+	require.Len(t, entries, 2)
+	require.Equal(t, "function", entries[0]["type"])
+	require.Equal(t, "openrouter:web_search", entries[1]["type"])
+}
+
+func TestBuildPayload_ServerToolsWithoutToolbox(t *testing.T) {
+	webSearch := map[string]any{"type": "openrouter:web_search"}
+
+	m := NewChatCompletionsAPI("", "gpt-5").WithServerTools(webSearch)
+	payload, err := m.BuildPayload(content.FromText("hi"), nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []any{webSearch}, payload["tools"])
+	_, hasChoice := payload["tool_choice"]
+	require.False(t, hasChoice)
+}


### PR DESCRIPTION
Provider-executed tools like OpenRouter's `openrouter:web_search` have non-function types the `Tool` struct cannot express, and a `tools` custom payload value is clobbered whenever a toolbox is present (payload assembly overwrites `payload["tools"]` unconditionally).

`WithServerTools(...any)` appends the given entries verbatim to the request's `tools` array after the toolbox's function tools, or sends them alone when there is no toolbox. Server tools run inside the provider's request loop and never surface as client tool calls, so they stay out of the toolbox and are exempt from `tool_choice` constraints.

Needed by flitsinc/builder BSCT-3257: attaching OpenRouter's server-side web search to editor agent LLM calls (the builder's OpenRouter provider is a type alias of `ChatCompletionsAPI`).

Tests: payload assembly with and without a toolbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)