### PR TITLE
Surface provider-executed search citations from chat-completions streams

### DIFF
--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -598,6 +598,25 @@ type ChatCompletionsStream struct {
 	lastText    string
 	lastThought *content.Thought
 	usage       *usage
+
+	// Citations from provider-executed searches (url_citation annotations),
+	// deduplicated by URL. Aggregated into one SearchActivity emitted at the
+	// end of the stream, because the citations arrive one per chunk with no
+	// per-search grouping or query.
+	searchSources  []llms.SearchSource
+	seenSearchURLs map[string]struct{}
+}
+
+// Search implements the optional provider-run search capability: one
+// aggregated activity for all citations the stream carried. The query is
+// unknown at this API level — the provider composes it server-side and only
+// the citations surface.
+func (s *ChatCompletionsStream) Search() llms.SearchActivity {
+	return llms.SearchActivity{
+		Source:      "web",
+		ResultCount: len(s.searchSources),
+		Sources:     s.searchSources,
+	}
 }
 
 func (s *ChatCompletionsStream) Err() error {
@@ -840,6 +859,12 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 					rawYield(llms.StreamStatusThinkingDone)
 				}
 			}
+			// Provider-executed search citations stream one per chunk with no
+			// grouping, so the aggregated activity is emitted once, when the
+			// stream is done and all sources are known.
+			if len(s.searchSources) > 0 && !stopped {
+				rawYield(llms.StreamStatusSearch)
+			}
 		}()
 		for {
 			select {
@@ -950,6 +975,21 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 				}, yield) {
 					return
 				}
+			}
+
+			for _, annotation := range delta.Annotations {
+				citation := annotation.URLCitation
+				if annotation.Type != "url_citation" || citation.URL == "" {
+					continue
+				}
+				if s.seenSearchURLs == nil {
+					s.seenSearchURLs = make(map[string]struct{})
+				}
+				if _, seen := s.seenSearchURLs[citation.URL]; seen {
+					continue
+				}
+				s.seenSearchURLs[citation.URL] = struct{}{}
+				s.searchSources = append(s.searchSources, llms.SearchSource{Title: citation.Title, URL: citation.URL})
 			}
 
 			// Content is nullable string in delta

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -1140,3 +1140,55 @@ func TestBuildPayload_ServerToolsWithoutToolbox(t *testing.T) {
 	_, hasChoice := payload["tool_choice"]
 	require.False(t, hasChoice)
 }
+
+func TestChatCompletionsStream_SearchAnnotationsAggregate(t *testing.T) {
+	// OpenRouter streams provider-executed search citations one url_citation
+	// per chunk, with duplicates possible across searches. The stream emits one
+	// aggregated search activity at the end with URL-deduplicated sources.
+	sse := strings.Join([]string{
+		`data: {"id":"gen_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"annotations":[{"type":"url_citation","url_citation":{"url":"https://nodejs.org/en","title":"Node.js"}}]}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"annotations":[{"type":"url_citation","url_citation":{"url":"https://endoflife.date/nodejs","title":"endoflife"}}]}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"annotations":[{"type":"url_citation","url_citation":{"url":"https://nodejs.org/en","title":"Node.js"}}]}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"content":"Answer"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+
+	var searches []llms.SearchActivity
+	var sawTextBeforeSearch bool
+	for status := range stream.Iter() {
+		switch status {
+		case llms.StreamStatusText:
+			sawTextBeforeSearch = len(searches) == 0
+		case llms.StreamStatusSearch:
+			searches = append(searches, stream.Search())
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, searches, 1)
+	assert.True(t, sawTextBeforeSearch, "search activity must aggregate at stream end, after content")
+	assert.Equal(t, "web", searches[0].Source)
+	assert.Equal(t, 2, searches[0].ResultCount)
+	assert.Equal(t, []llms.SearchSource{
+		{Title: "Node.js", URL: "https://nodejs.org/en"},
+		{Title: "endoflife", URL: "https://endoflife.date/nodejs"},
+	}, searches[0].Sources)
+}
+
+func TestChatCompletionsStream_NoSearchWithoutAnnotations(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"id":"gen_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"content":"Answer"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+	for status := range stream.Iter() {
+		require.NotEqual(t, llms.StreamStatusSearch, status)
+	}
+	require.NoError(t, stream.Err())
+}

--- a/openai/chatcompletions_types.go
+++ b/openai/chatcompletions_types.go
@@ -482,12 +482,24 @@ type ReasoningDetail struct {
 }
 
 type chatCompletionDelta struct {
-	Role             string            `json:"role,omitempty"`
-	Content          *string           `json:"content,omitempty"`
-	Refusal          *string           `json:"refusal,omitempty"`
-	Reasoning        *string           `json:"reasoning,omitempty"`
-	ReasoningDetails []ReasoningDetail `json:"reasoning_details,omitempty"`
-	ToolCalls        []toolCallDelta   `json:"tool_calls,omitempty"`
+	Role             string                     `json:"role,omitempty"`
+	Content          *string                    `json:"content,omitempty"`
+	Refusal          *string                    `json:"refusal,omitempty"`
+	Reasoning        *string                    `json:"reasoning,omitempty"`
+	ReasoningDetails []ReasoningDetail          `json:"reasoning_details,omitempty"`
+	ToolCalls        []toolCallDelta            `json:"tool_calls,omitempty"`
+	Annotations      []chatCompletionAnnotation `json:"annotations,omitempty"`
+}
+
+// chatCompletionAnnotation carries a citation for a provider-executed search.
+// OpenRouter streams one url_citation per chunk while its server-side web
+// search injects results into the model's context.
+type chatCompletionAnnotation struct {
+	Type        string `json:"type"`
+	URLCitation struct {
+		URL   string `json:"url"`
+		Title string `json:"title"`
+	} `json:"url_citation"`
 }
 
 type logprobsContent struct {


### PR DESCRIPTION
OpenRouter's server-side web search (`openrouter:web_search`) streams its citations as one `url_citation` annotation per chunk, with no per-search grouping and no query. The chat-completions stream now collects them, deduplicated by URL, and emits a single aggregated `StreamStatusSearch` at stream end, implementing the optional `Search()` capability that `llms.go`'s update loop already dispatches on (previously only the Responses API stream implemented it). Streams without annotations are unaffected.

Chunk shape verified live against OpenRouter (anthropic + openai families). Needed by flitsinc/builder BSCT-3275: making editor server-side searches visible as `search` SSE events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive streaming behavior behind optional annotations; no changes to auth, requests, or existing stream paths without citations.
> 
> **Overview**
> **Chat Completions streaming** now surfaces **provider-executed web search** (e.g. OpenRouter `openrouter:web_search`) the same way the Responses API stream already does.
> 
> Stream deltas can include `url_citation` **annotations**; the parser collects title/URL pairs, **deduplicates by URL**, and defers a single **`StreamStatusSearch`** until the stream finishes (citations arrive per chunk with no query or per-search grouping). **`ChatCompletionsStream.Search()`** returns one aggregated **`SearchActivity`** (`source: "web"`, sources list). Streams without annotations are unchanged.
> 
> Types add **`Annotations`** on **`chatCompletionDelta`** plus **`chatCompletionAnnotation`**. Tests cover URL dedup, end-of-stream ordering after text, and no search when annotations are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85426ebc5ba5b91c70f6455e7d27eead602a87cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->