### PR TITLE
Guard the deferred search yield against a mid-defer consumer stop

### DIFF
--- a/openai/chatcompletions.go
+++ b/openai/chatcompletions.go
@@ -852,11 +852,13 @@ func (s *ChatCompletionsStream) Iter() func(yield func(llms.StreamStatus) bool) 
 		defer func() {
 			// Ensure ThinkingDone is emitted if the stream ends abnormally
 			// (e.g. EOF without [DONE]) while still in thinking state.
-			// Don't call yield if the consumer already stopped iterating.
+			// Don't call yield if the consumer already stopped iterating, and
+			// record a mid-defer stop so the search emission below cannot call
+			// a yield that already returned false (a range-over-func panic).
 			if s.lastThought != nil {
 				s.lastThought = nil
-				if !stopped {
-					rawYield(llms.StreamStatusThinkingDone)
+				if !stopped && !rawYield(llms.StreamStatusThinkingDone) {
+					stopped = true
 				}
 			}
 			// Provider-executed search citations stream one per chunk with no

--- a/openai/chatcompletions_test.go
+++ b/openai/chatcompletions_test.go
@@ -1192,3 +1192,22 @@ func TestChatCompletionsStream_NoSearchWithoutAnnotations(t *testing.T) {
 	}
 	require.NoError(t, stream.Err())
 }
+
+func TestChatCompletionsStream_ConsumerStopDuringDeferredThinkingDone(t *testing.T) {
+	// Abnormal EOF while thinking, with citations collected: if the consumer
+	// stops on the deferred ThinkingDone, the deferred search emission must not
+	// call the already-finished yield (that would panic the process).
+	sse := strings.Join([]string{
+		`data: {"id":"gen_1","choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"annotations":[{"type":"url_citation","url_citation":{"url":"https://example.com","title":"Example"}}]}}]}`,
+		`data: {"id":"gen_1","choices":[{"delta":{"reasoning":"thinking..."}}]}`,
+		"",
+	}, "\n")
+
+	stream := &ChatCompletionsStream{ctx: context.Background(), model: "test", stream: strings.NewReader(sse)}
+	for status := range stream.Iter() {
+		if status == llms.StreamStatusThinkingDone {
+			break
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #84: if the consumer breaks on the deferred ThinkingDone yield (abnormal EOF while thinking, citations collected), the deferred search emission called a yield that had already returned false — a range-over-func panic. The stop is now recorded between the two deferred yields. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small streaming iterator fix with a regression test; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes a **range-over-func panic** in `ChatCompletionsStream.Iter()` when a stream ends abnormally (e.g. EOF without `[DONE]`) while still in a thinking state and search citations were collected.
> 
> The defer path emits deferred `ThinkingDone`, then aggregated `Search`. If the consumer **stops on `ThinkingDone`**, the code used to still call `rawYield` for `Search` because `stopped` was only set by the wrapped `yield` helper—not when defer called `rawYield` directly. The defer now **sets `stopped` when deferred `ThinkingDone` returns false**, so the deferred search emission is skipped.
> 
> Adds **`TestChatCompletionsStream_ConsumerStopDuringDeferredThinkingDone`** to lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535001db3ecddd3e66f19592a68da8eb307673f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->